### PR TITLE
feat: Phase 1+2 — Foundation and Services

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 env:
   DOTNET_NOLOGO: true
@@ -28,8 +29,8 @@ jobs:
       - name: Authenticate to GitHub Packages
         run: |
           dotnet nuget update source granit-registry \
-            --username granit-fx \
-            --password ${{ secrets.GRANIT_PACKAGES_TOKEN }} \
+            --username ${{ github.actor }} \
+            --password ${{ secrets.GITHUB_TOKEN }} \
             --store-password-in-clear-text \
             --configfile nuget.config
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Authenticate to GitHub Packages
         run: |
           dotnet nuget update source granit-registry \
-            --username ${{ github.actor }} \
-            --password ${{ secrets.GITHUB_TOKEN }} \
+            --username granit-fx \
+            --password ${{ secrets.GRANIT_PACKAGES_TOKEN }} \
             --store-password-in-clear-text \
             --configfile nuget.config
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,6 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
 
-    services:
-      docker:
-        image: docker:dind
-        options: --privileged
-
     steps:
       - uses: actions/checkout@v4
 
@@ -33,8 +28,8 @@ jobs:
       - name: Authenticate to GitHub Packages
         run: |
           dotnet nuget update source granit-registry \
-            --username ${{ github.actor }} \
-            --password ${{ secrets.GITHUB_TOKEN }} \
+            --username granit-fx \
+            --password ${{ secrets.GRANIT_PACKAGES_TOKEN }} \
             --store-password-in-clear-text \
             --configfile nuget.config
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    services:
+      docker:
+        image: docker:dind
+        options: --privileged
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Authenticate to GitHub Packages
+        run: |
+          dotnet nuget update source granit-registry \
+            --username ${{ github.actor }} \
+            --password ${{ secrets.GITHUB_TOKEN }} \
+            --store-password-in-clear-text \
+            --configfile nuget.config
+
+      - name: Restore
+        run: dotnet restore GranitMicroservice.slnx
+
+      - name: Build
+        run: dotnet build GranitMicroservice.slnx --no-restore
+
+      - name: Unit Tests
+        run: >-
+          dotnet test GranitMicroservice.slnx
+          --no-build
+          --filter "FullyQualifiedName!~Integration"
+          --logger "trx;LogFileName=unit-tests.trx"
+
+      - name: Integration Tests
+        run: >-
+          dotnet test GranitMicroservice.slnx
+          --no-build
+          --filter "FullyQualifiedName~Integration"
+          --logger "trx;LogFileName=integration-tests.trx"

--- a/.github/workflows/template-validation.yml
+++ b/.github/workflows/template-validation.yml
@@ -1,0 +1,66 @@
+name: Template Validation
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1" # Weekly Monday 06:00 UTC
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+
+jobs:
+  validate-template:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Install template from local source
+        run: dotnet new install .
+
+      - name: Scaffold solution
+        run: dotnet new granit-microservice -n TestScaffold -o /tmp/test-scaffold
+
+      - name: Authenticate to GitHub Packages
+        run: |
+          dotnet nuget add source \
+            https://nuget.pkg.github.com/granit-fx/index.json \
+            --name granit-registry \
+            --username ${{ github.actor }} \
+            --password ${{ secrets.GITHUB_TOKEN }} \
+            --store-password-in-clear-text \
+            --configfile /tmp/test-scaffold/nuget.config
+
+      - name: Build scaffolded solution
+        run: dotnet build /tmp/test-scaffold/TestScaffold.slnx
+
+      - name: Verify file renaming
+        run: |
+          test -f /tmp/test-scaffold/TestScaffold.slnx
+          test -d /tmp/test-scaffold/src/TestScaffold.AppHost
+          test -d /tmp/test-scaffold/src/TestScaffold.CatalogService
+          test -d /tmp/test-scaffold/src/TestScaffold.IdentityService
+          echo "All files renamed correctly"
+
+      - name: Create issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: '[CI] Template validation failed',
+              body: `Template validation failed on ${new Date().toISOString()}.\n\nSee [workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.`,
+              labels: ['bug', 'Area: CI/CD']
+            });

--- a/.github/workflows/template-validation.yml
+++ b/.github/workflows/template-validation.yml
@@ -33,11 +33,9 @@ jobs:
 
       - name: Authenticate to GitHub Packages
         run: |
-          dotnet nuget add source \
-            https://nuget.pkg.github.com/granit-fx/index.json \
-            --name granit-registry \
-            --username ${{ github.actor }} \
-            --password ${{ secrets.GITHUB_TOKEN }} \
+          dotnet nuget update source granit-registry \
+            --username granit-fx \
+            --password ${{ secrets.GRANIT_PACKAGES_TOKEN }} \
             --store-password-in-clear-text \
             --configfile /tmp/test-scaffold/nuget.config
 

--- a/.github/workflows/template-validation.yml
+++ b/.github/workflows/template-validation.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
   issues: write
 
 env:
@@ -34,8 +35,8 @@ jobs:
       - name: Authenticate to GitHub Packages
         run: |
           dotnet nuget update source granit-registry \
-            --username granit-fx \
-            --password ${{ secrets.GRANIT_PACKAGES_TOKEN }} \
+            --username ${{ github.actor }} \
+            --password ${{ secrets.GITHUB_TOKEN }} \
             --store-password-in-clear-text \
             --configfile /tmp/test-scaffold/nuget.config
 

--- a/.github/workflows/template-validation.yml
+++ b/.github/workflows/template-validation.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Authenticate to GitHub Packages
         run: |
           dotnet nuget update source granit-registry \
-            --username ${{ github.actor }} \
-            --password ${{ secrets.GITHUB_TOKEN }} \
+            --username granit-fx \
+            --password ${{ secrets.GRANIT_PACKAGES_TOKEN }} \
             --store-password-in-clear-text \
             --configfile /tmp/test-scaffold/nuget.config
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+## .NET
+bin/
+obj/
+*.user
+*.suo
+*.userosscache
+*.sln.docstates
+nupkgs/
+packages.lock.json
+
+## IDE
+.vs/
+.vscode/
+.idea/
+*.swp
+*~
+
+## OS
+.DS_Store
+Thumbs.db
+
+## Aspire
+.dcproj.user

--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Digital Dynamics",
+  "classifications": ["Web", "API", "Microservices", "Aspire", "Granit"],
+  "identity": "Granit.Templates.Microservice",
+  "name": "Granit Microservice Solution",
+  "shortName": "granit-microservice",
+  "description": "A complete Granit microservice solution with .NET Aspire orchestration, API Gateway (YARP), multiple services, Wolverine messaging, and Keycloak authentication.",
+  "tags": {
+    "language": "C#",
+    "type": "solution"
+  },
+  "sourceName": "GranitMicroservice",
+  "preferNameDirectory": true,
+  "defaultName": "MyMicroservices",
+  "symbols": {
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the solution.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net10.0",
+          "description": "Target .NET 10"
+        }
+      ],
+      "defaultValue": "net10.0",
+      "replaces": "net10.0"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the solution on create.",
+      "defaultValue": "false"
+    }
+  },
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "exclude": [
+            ".git/**",
+            ".github/**",
+            ".template.config/**",
+            "**/.vs/**",
+            "**/bin/**",
+            "**/obj/**",
+            "**/*.user",
+            "**/packages.lock.json",
+            "CLAUDE.md"
+          ]
+        }
+      ]
+    }
+  ],
+  "primaryOutputs": [
+    {
+      "path": "GranitMicroservice.slnx"
+    }
+  ],
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this solution.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,106 @@
+# CLAUDE.md - Granit Microservice Template
+
+## Project
+
+- **Type**: .NET Aspire solution template for Granit microservices
+- **Repo**: `granit-fx/granit-microservice-template` (GitHub, open-source)
+- **License**: Apache-2.0
+- **Framework**: Granit consumed via NuGet (`0.1.*`), NOT via ProjectReference
+- **Reference repo**: `granit-dotnet` — see `templates/granit-api-full/` for patterns
+
+## Stack and versions
+
+.NET 10 (LTS) | C# 14 | .NET Aspire 9 | EF Core 10 | Wolverine 5.20+ | YARP
+
+## Architecture
+
+```text
+src/
+  GranitMicroservice.AppHost/          # .NET Aspire orchestration
+  GranitMicroservice.ServiceDefaults/  # OpenTelemetry, health checks, resilience
+  GranitMicroservice.ApiGateway/       # YARP reverse proxy + auth
+  GranitMicroservice.Shared/           # Integration event contracts only
+  GranitMicroservice.Shared.Hosting/   # Cross-cutting concerns (NO business packages)
+  GranitMicroservice.IdentityService/
+  GranitMicroservice.CatalogService/
+  GranitMicroservice.NotificationService/
+
+tests/
+  GranitMicroservice.CatalogService.Tests/
+  GranitMicroservice.CatalogService.Tests.Integration/
+  GranitMicroservice.IdentityService.Tests/
+  GranitMicroservice.NotificationService.Tests/
+
+infra/keycloak-realms/                 # Keycloak realm JSON for Aspire import
+```
+
+## Commands
+
+```bash
+# Build entire solution
+dotnet build GranitMicroservice.slnx
+
+# Run tests
+dotnet test GranitMicroservice.slnx
+
+# Start all services via Aspire
+dotnet run --project src/GranitMicroservice.AppHost
+
+# Scaffold from template
+dotnet new granit-microservice -n Acme.Platform -o /tmp/acme
+dotnet build /tmp/acme/Acme.Platform.slnx
+```
+
+## Template mechanics
+
+- `sourceName: "GranitMicroservice"` in `.template.config/template.json`
+- `dotnet new` replaces all occurrences of `GranitMicroservice` with the user's name
+- Solution file: `.slnx` (modern XML format, NOT `.sln`)
+- Central Package Management: all versions in `Directory.Packages.props`
+
+## Key conventions
+
+### Shared.Hosting boundaries
+
+Cross-cutting concerns ONLY. Allowed packages:
+
+- `Granit.Core`, `Granit.Bundle.Essentials`
+- `Granit.Wolverine.Postgresql`, `Granit.EventBus.Wolverine`
+- `Granit.Authentication.JwtBearer`
+- `Granit.Caching.StackExchangeRedis`
+- `Granit.Http.Resilience`
+
+FORBIDDEN in Shared.Hosting: `Granit.Identity`, `Granit.Notifications`,
+`Granit.Authorization` — these belong in each service's `Program.cs` / module.
+
+### Database isolation
+
+Each microservice owns its PostgreSQL database. No shared databases.
+
+### Communication patterns
+
+1. **Synchrone**: Gateway to services via YARP; inter-service via HttpClient + resilience
+2. **Asynchrone**: Wolverine + RabbitMQ + transactional outbox (PostgreSQL)
+3. **Cache**: Redis via `Granit.Caching.StackExchangeRedis`
+
+### No Docker Compose
+
+Aspire orchestrates everything. No `docker-compose.yml`.
+
+## Code quality
+
+Follows `granit-dotnet` conventions (see its CLAUDE.md):
+
+- C# 14: primary constructors, collection expressions, `field` keyword, extension members
+- `[LoggerMessage]` for logging, `TimeProvider` for time, `[GeneratedRegex]` for regex
+- `TypedResults` for API responses, `*Request`/`*Response` DTOs (never `*Dto`)
+- File-scoped namespaces, `var` when type is apparent
+
+## Anti-patterns
+
+- No `DateTime.Now`/`UtcNow` — inject `TimeProvider`
+- No `new Regex(...)` — use `[GeneratedRegex]`
+- No Swashbuckle/NSwag — use `Microsoft.AspNetCore.OpenApi` + Scalar
+- No `docker-compose` — Aspire only
+- No shared DbContext across services
+- No business packages in Shared.Hosting

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
+    <NoWarn>CA1848;CA1707;CA1305;CS1591</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
-    <NoWarn>CA1848;CA1707;CA1305;CS1591</NoWarn>
+    <NoWarn>CA1848;CA1707;CA1305;CA1716;CS1591</NoWarn>
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,108 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageFloatingVersionsEnabled>true</CentralPackageFloatingVersionsEnabled>
+  </PropertyGroup>
+
+  <!-- Granit framework -->
+  <ItemGroup Label="Granit">
+    <PackageVersion Include="Granit.Core" Version="0.1.*" />
+    <PackageVersion Include="Granit.Bundle.Essentials" Version="0.1.*" />
+    <PackageVersion Include="Granit.Authentication.JwtBearer" Version="0.1.*" />
+    <PackageVersion Include="Granit.Authentication.Keycloak" Version="0.1.*" />
+    <PackageVersion Include="Granit.Authorization" Version="0.1.*" />
+    <PackageVersion Include="Granit.Caching.StackExchangeRedis" Version="0.1.*" />
+    <PackageVersion Include="Granit.Diagnostics" Version="0.1.*" />
+    <PackageVersion Include="Granit.EventBus" Version="0.1.*" />
+    <PackageVersion Include="Granit.EventBus.Wolverine" Version="0.1.*" />
+    <PackageVersion Include="Granit.Http.Resilience" Version="0.1.*" />
+    <PackageVersion Include="Granit.Identity" Version="0.1.*" />
+    <PackageVersion Include="Granit.Identity.Keycloak" Version="0.1.*" />
+    <PackageVersion Include="Granit.Identity.EntityFrameworkCore" Version="0.1.*" />
+    <PackageVersion Include="Granit.Identity.Endpoints" Version="0.1.*" />
+    <PackageVersion Include="Granit.Notifications" Version="0.1.*" />
+    <PackageVersion Include="Granit.Observability" Version="0.1.*" />
+    <PackageVersion Include="Granit.Persistence" Version="0.1.*" />
+    <PackageVersion Include="Granit.Persistence.Migrations" Version="0.1.*" />
+    <PackageVersion Include="Granit.RateLimiting" Version="0.1.*" />
+    <PackageVersion Include="Granit.Wolverine" Version="0.1.*" />
+    <PackageVersion Include="Granit.Wolverine.Postgresql" Version="0.1.*" />
+  </ItemGroup>
+
+  <!-- .NET Aspire -->
+  <ItemGroup Label="Aspire">
+    <PackageVersion Include="Aspire.AppHost.Sdk" Version="9.*" />
+    <PackageVersion Include="Aspire.Hosting" Version="9.*" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.*" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="9.*" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="9.*" />
+    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="9.*" />
+  </ItemGroup>
+
+  <!-- ASP.NET Core -->
+  <ItemGroup Label="ASP.NET Core">
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.*" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.*" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.*" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.*" />
+  </ItemGroup>
+
+  <!-- Entity Framework Core -->
+  <ItemGroup Label="Entity Framework Core">
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.*" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.*" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.*" />
+  </ItemGroup>
+
+  <!-- Wolverine -->
+  <ItemGroup Label="Wolverine">
+    <PackageVersion Include="WolverineFx" Version="5.20.*" />
+    <PackageVersion Include="WolverineFx.Postgresql" Version="5.20.*" />
+  </ItemGroup>
+
+  <!-- YARP -->
+  <ItemGroup Label="YARP">
+    <PackageVersion Include="Yarp.ReverseProxy" Version="2.*" />
+  </ItemGroup>
+
+  <!-- Validation -->
+  <ItemGroup Label="Validation">
+    <PackageVersion Include="FluentValidation" Version="12.*" />
+    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.*" />
+  </ItemGroup>
+
+  <!-- Observability -->
+  <ItemGroup Label="Observability">
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.*" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.*" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.*" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.*" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.*" />
+  </ItemGroup>
+
+  <!-- Cache -->
+  <ItemGroup Label="Cache">
+    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.*" />
+  </ItemGroup>
+
+  <!-- Health checks -->
+  <ItemGroup Label="Health Checks">
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.*" />
+    <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.*" />
+    <PackageVersion Include="AspNetCore.HealthChecks.Redis" Version="9.*" />
+    <PackageVersion Include="AspNetCore.HealthChecks.Rabbitmq" Version="9.*" />
+  </ItemGroup>
+
+  <!-- Tests -->
+  <ItemGroup Label="Tests">
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.*" />
+    <PackageVersion Include="xunit.v3" Version="3.2.*" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.*" />
+    <PackageVersion Include="NSubstitute" Version="5.*" />
+    <PackageVersion Include="Shouldly" Version="4.*" />
+    <PackageVersion Include="Bogus" Version="35.*" />
+    <PackageVersion Include="coverlet.collector" Version="8.*" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.*" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="9.*" />
+  </ItemGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,27 +6,27 @@
 
   <!-- Granit framework -->
   <ItemGroup Label="Granit">
-    <PackageVersion Include="Granit.Core" Version="0.1.*" />
-    <PackageVersion Include="Granit.Bundle.Essentials" Version="0.1.*" />
-    <PackageVersion Include="Granit.Authentication.JwtBearer" Version="0.1.*" />
-    <PackageVersion Include="Granit.Authentication.Keycloak" Version="0.1.*" />
-    <PackageVersion Include="Granit.Authorization" Version="0.1.*" />
-    <PackageVersion Include="Granit.Caching.StackExchangeRedis" Version="0.1.*" />
-    <PackageVersion Include="Granit.Diagnostics" Version="0.1.*" />
-    <PackageVersion Include="Granit.EventBus" Version="0.1.*" />
-    <PackageVersion Include="Granit.EventBus.Wolverine" Version="0.1.*" />
-    <PackageVersion Include="Granit.Http.Resilience" Version="0.1.*" />
-    <PackageVersion Include="Granit.Identity" Version="0.1.*" />
-    <PackageVersion Include="Granit.Identity.Keycloak" Version="0.1.*" />
-    <PackageVersion Include="Granit.Identity.EntityFrameworkCore" Version="0.1.*" />
-    <PackageVersion Include="Granit.Identity.Endpoints" Version="0.1.*" />
-    <PackageVersion Include="Granit.Notifications" Version="0.1.*" />
-    <PackageVersion Include="Granit.Observability" Version="0.1.*" />
-    <PackageVersion Include="Granit.Persistence" Version="0.1.*" />
-    <PackageVersion Include="Granit.Persistence.Migrations" Version="0.1.*" />
-    <PackageVersion Include="Granit.RateLimiting" Version="0.1.*" />
-    <PackageVersion Include="Granit.Wolverine" Version="0.1.*" />
-    <PackageVersion Include="Granit.Wolverine.Postgresql" Version="0.1.*" />
+    <PackageVersion Include="Granit.Core" Version="0.1.0-*" />
+    <PackageVersion Include="Granit.Bundle.Essentials" Version="0.1.0-*" />
+    <PackageVersion Include="Granit.Authentication.JwtBearer" Version="0.1.0-*" />
+    <PackageVersion Include="Granit.Authentication.Keycloak" Version="0.1.0-*" />
+    <PackageVersion Include="Granit.Authorization" Version="0.1.0-*" />
+    <PackageVersion Include="Granit.Caching.StackExchangeRedis" Version="0.1.0-*" />
+    <PackageVersion Include="Granit.Diagnostics" Version="0.1.0-*" />
+    <PackageVersion Include="Granit.EventBus" Version="0.1.0-*" />
+    <PackageVersion Include="Granit.EventBus.Wolverine" Version="0.1.0-*" />
+    <PackageVersion Include="Granit.Http.Resilience" Version="0.1.0-*" />
+    <PackageVersion Include="Granit.Identity" Version="0.1.0-*" />
+    <PackageVersion Include="Granit.Identity.Keycloak" Version="0.1.0-*" />
+    <PackageVersion Include="Granit.Identity.EntityFrameworkCore" Version="0.1.0-*" />
+    <PackageVersion Include="Granit.Identity.Endpoints" Version="0.1.0-*" />
+    <PackageVersion Include="Granit.Notifications" Version="0.1.0-*" />
+    <PackageVersion Include="Granit.Observability" Version="0.1.0-*" />
+    <PackageVersion Include="Granit.Persistence" Version="0.1.0-*" />
+    <PackageVersion Include="Granit.Persistence.Migrations" Version="0.1.0-*" />
+    <PackageVersion Include="Granit.RateLimiting" Version="0.1.0-*" />
+    <PackageVersion Include="Granit.Wolverine" Version="0.1.0-*" />
+    <PackageVersion Include="Granit.Wolverine.Postgresql" Version="0.1.0-*" />
   </ItemGroup>
 
   <!-- .NET Aspire -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,6 +36,7 @@
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.*" />
     <PackageVersion Include="Aspire.Hosting.Redis" Version="13.*" />
     <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.*" />
+    <PackageVersion Include="Aspire.Hosting.Keycloak" Version="13.1.2-preview.*" />
   </ItemGroup>
 
   <!-- ASP.NET Core -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,12 +31,11 @@
 
   <!-- .NET Aspire -->
   <ItemGroup Label="Aspire">
-    <PackageVersion Include="Aspire.AppHost.Sdk" Version="9.*" />
-    <PackageVersion Include="Aspire.Hosting" Version="9.*" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.*" />
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="9.*" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="9.*" />
-    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="9.*" />
+    <PackageVersion Include="Aspire.Hosting" Version="13.*" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.*" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.*" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.*" />
+    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.*" />
   </ItemGroup>
 
   <!-- ASP.NET Core -->
@@ -44,7 +43,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.*" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.*" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.*" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.*" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.*" />
   </ItemGroup>
 
   <!-- Entity Framework Core -->
@@ -103,6 +102,6 @@
     <PackageVersion Include="Bogus" Version="35.*" />
     <PackageVersion Include="coverlet.collector" Version="8.*" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.*" />
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="9.*" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.*" />
   </ItemGroup>
 </Project>

--- a/GranitMicroservice.slnx
+++ b/GranitMicroservice.slnx
@@ -13,5 +13,6 @@
     <Project Path="tests/GranitMicroservice.CatalogService.Tests/GranitMicroservice.CatalogService.Tests.csproj" />
     <Project Path="tests/GranitMicroservice.IdentityService.Tests/GranitMicroservice.IdentityService.Tests.csproj" />
     <Project Path="tests/GranitMicroservice.NotificationService.Tests/GranitMicroservice.NotificationService.Tests.csproj" />
+    <Project Path="tests/GranitMicroservice.CatalogService.Tests.Integration/GranitMicroservice.CatalogService.Tests.Integration.csproj" />
   </Folder>
 </Solution>

--- a/GranitMicroservice.slnx
+++ b/GranitMicroservice.slnx
@@ -2,6 +2,8 @@
   <Folder Name="/src/">
     <Project Path="src/GranitMicroservice.AppHost/GranitMicroservice.AppHost.csproj" />
     <Project Path="src/GranitMicroservice.ServiceDefaults/GranitMicroservice.ServiceDefaults.csproj" />
+    <Project Path="src/GranitMicroservice.Shared/GranitMicroservice.Shared.csproj" />
+    <Project Path="src/GranitMicroservice.Shared.Hosting/GranitMicroservice.Shared.Hosting.csproj" />
     <Project Path="src/GranitMicroservice.ApiGateway/GranitMicroservice.ApiGateway.csproj" />
     <Project Path="src/GranitMicroservice.IdentityService/GranitMicroservice.IdentityService.csproj" />
     <Project Path="src/GranitMicroservice.CatalogService/GranitMicroservice.CatalogService.csproj" />

--- a/GranitMicroservice.slnx
+++ b/GranitMicroservice.slnx
@@ -9,4 +9,9 @@
     <Project Path="src/GranitMicroservice.CatalogService/GranitMicroservice.CatalogService.csproj" />
     <Project Path="src/GranitMicroservice.NotificationService/GranitMicroservice.NotificationService.csproj" />
   </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/GranitMicroservice.CatalogService.Tests/GranitMicroservice.CatalogService.Tests.csproj" />
+    <Project Path="tests/GranitMicroservice.IdentityService.Tests/GranitMicroservice.IdentityService.Tests.csproj" />
+    <Project Path="tests/GranitMicroservice.NotificationService.Tests/GranitMicroservice.NotificationService.Tests.csproj" />
+  </Folder>
 </Solution>

--- a/GranitMicroservice.slnx
+++ b/GranitMicroservice.slnx
@@ -1,0 +1,10 @@
+<Solution>
+  <Folder Name="/src/">
+    <Project Path="src/GranitMicroservice.AppHost/GranitMicroservice.AppHost.csproj" />
+    <Project Path="src/GranitMicroservice.ServiceDefaults/GranitMicroservice.ServiceDefaults.csproj" />
+    <Project Path="src/GranitMicroservice.ApiGateway/GranitMicroservice.ApiGateway.csproj" />
+    <Project Path="src/GranitMicroservice.IdentityService/GranitMicroservice.IdentityService.csproj" />
+    <Project Path="src/GranitMicroservice.CatalogService/GranitMicroservice.CatalogService.csproj" />
+    <Project Path="src/GranitMicroservice.NotificationService/GranitMicroservice.NotificationService.csproj" />
+  </Folder>
+</Solution>

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 A production-ready .NET Aspire solution template for building microservices
 with the [Granit framework](https://github.com/granit-fx/granit-dotnet).
+Full documentation at [granit-fx.dev](https://granit-fx.dev).
 
 ## What's included
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,80 @@
+# Granit Microservice Template
+
+A production-ready .NET Aspire solution template for building microservices
+with the [Granit framework](https://github.com/granit-fx/granit-dotnet).
+
+## What's included
+
+| Project | Role |
+|---------|------|
+| **AppHost** | .NET Aspire orchestration (PostgreSQL, Redis, RabbitMQ, Keycloak) |
+| **ServiceDefaults** | OpenTelemetry, health checks, resilient HTTP clients |
+| **Shared** | Integration event contracts (`IIntegrationEvent`) |
+| **Shared.Hosting** | Cross-cutting concerns (Wolverine outbox, JWT, Redis) |
+| **CatalogService** | Domain entities, CRUD endpoints, event publishing |
+| **IdentityService** | Keycloak integration via Granit.Identity |
+| **NotificationService** | Event-driven Wolverine handlers |
+| **ApiGateway** | YARP reverse proxy, JWT auth, rate limiting, Scalar UI |
+
+## Prerequisites
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
+- [Docker](https://www.docker.com/products/docker-desktop/) (for Aspire containers)
+- Access to [Granit GitHub Packages](https://github.com/orgs/granit-fx/packages)
+
+## Quick start
+
+```bash
+# Install the template
+dotnet new install .
+
+# Scaffold a new solution
+dotnet new granit-microservice -n Acme.Platform -o ./acme-platform
+
+# Run with Aspire
+cd acme-platform
+dotnet run --project src/Acme.Platform.AppHost
+```
+
+The Aspire dashboard opens automatically with all services, databases,
+and infrastructure visible.
+
+## Architecture
+
+```text
+┌─────────────┐
+│  API Gateway │  YARP + JWT + Rate Limiting
+│  (Scalar UI) │
+└──────┬───┬──┘
+       │   │
+  ┌────┘   └────┐
+  ▼              ▼
+┌──────────┐  ┌──────────────┐
+│ Identity │  │   Catalog    │
+│ Service  │  │   Service    │──┐
+└──────────┘  └──────────────┘  │ events
+                                ▼
+                        ┌───────────────┐
+                        │ Notification  │
+                        │   Service     │
+                        └───────────────┘
+
+Infrastructure (Aspire-managed):
+  PostgreSQL (1 DB per service) │ Redis │ RabbitMQ │ Keycloak
+```
+
+## Communication patterns
+
+1. **Synchronous**: Gateway to services via YARP, inter-service via
+   HttpClient + resilience + Aspire service discovery
+2. **Asynchronous**: Wolverine + RabbitMQ + PostgreSQL transactional outbox
+3. **Distributed cache**: Redis via `Granit.Caching.StackExchangeRedis`
+
+## Documentation
+
+- [Getting started](docs/getting-started.md) — step-by-step setup guide
+- [Architecture](docs/architecture.md) — design decisions and patterns
+
+## License
+
+[Apache-2.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -41,26 +41,29 @@ and infrastructure visible.
 
 ## Architecture
 
-```text
-┌─────────────┐
-│  API Gateway │  YARP + JWT + Rate Limiting
-│  (Scalar UI) │
-└──────┬───┬──┘
-       │   │
-  ┌────┘   └────┐
-  ▼              ▼
-┌──────────┐  ┌──────────────┐
-│ Identity │  │   Catalog    │
-│ Service  │  │   Service    │──┐
-└──────────┘  └──────────────┘  │ events
-                                ▼
-                        ┌───────────────┐
-                        │ Notification  │
-                        │   Service     │
-                        └───────────────┘
+```mermaid
+graph TD
+    Client([Client]) --> GW[API Gateway<br>YARP + JWT + Rate Limiting<br>Scalar UI]
+    GW --> IS[Identity Service]
+    GW --> CS[Catalog Service]
+    CS -- integration events --> MQ[(RabbitMQ)]
+    MQ --> NS[Notification Service]
 
-Infrastructure (Aspire-managed):
-  PostgreSQL (1 DB per service) │ Redis │ RabbitMQ │ Keycloak
+    IS --- IDB[(identity-db)]
+    CS --- CDB[(catalog-db)]
+    NS --- NDB[(notification-db)]
+
+    IS & CS & NS --- Redis[(Redis)]
+    IS --> KC[Keycloak]
+
+    subgraph Infrastructure
+        IDB
+        CDB
+        NDB
+        Redis
+        MQ
+        KC
+    end
 ```
 
 ## Communication patterns

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,8 +46,17 @@ accidental coupling between services.
 
 ### Synchronous (HTTP)
 
-```text
-Client → API Gateway (YARP) → Service
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant GW as API Gateway
+    participant S as Service
+
+    C->>GW: HTTP request + JWT
+    GW->>GW: Validate JWT
+    GW->>S: Forward (service discovery)
+    S-->>GW: Response
+    GW-->>C: Response
 ```
 
 - JWT validated at the gateway edge
@@ -56,8 +65,17 @@ Client → API Gateway (YARP) → Service
 
 ### Asynchronous (Integration Events)
 
-```text
-CatalogService → [PostgreSQL outbox] → RabbitMQ → NotificationService
+```mermaid
+sequenceDiagram
+    participant CS as CatalogService
+    participant DB as PostgreSQL outbox
+    participant MQ as RabbitMQ
+    participant NS as NotificationService
+
+    CS->>DB: Save entity + event (same tx)
+    DB-->>MQ: Deliver event
+    MQ-->>NS: Route to handler
+    NS->>NS: HandleAsync()
 ```
 
 - Events implement `IIntegrationEvent` (defined in `Shared`)
@@ -65,25 +83,23 @@ CatalogService → [PostgreSQL outbox] → RabbitMQ → NotificationService
 - Stored in PostgreSQL outbox before RabbitMQ delivery
 - Handlers auto-discovered by Wolverine via convention
 
-### Distributed cache
-
-```text
-Any Service → Redis (via Granit.Caching.StackExchangeRedis)
-```
-
 ## Module dependency graph
 
-```text
-AppHost
-  └── references all service projects (Aspire orchestration)
+```mermaid
+graph BT
+    Shared[Shared<br>integration events]
+    SD[ServiceDefaults<br>OTel, health checks]
+    SH[Shared.Hosting<br>Wolverine, JWT, Redis]
 
-ApiGateway
-  └── ServiceDefaults
+    SH --> SD
+    SH --> Shared
 
-IdentityService / CatalogService / NotificationService
-  └── Shared.Hosting
-        ├── ServiceDefaults (OpenTelemetry, health checks)
-        └── Shared (integration event contracts)
+    IS[IdentityService] --> SH
+    CS[CatalogService] --> SH
+    NS[NotificationService] --> SH
+    GW[ApiGateway] --> SD
+
+    AH[AppHost] -.-> IS & CS & NS & GW
 ```
 
 ## Health check probes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,103 @@
+# Architecture
+
+## Design decisions
+
+### Aspire over Docker Compose
+
+.NET Aspire provides declarative C# orchestration with automatic service
+discovery, connection string injection, and a built-in dashboard. No YAML
+maintenance, no port conflicts, no manual environment variables.
+
+### YARP over Ocelot
+
+YARP is Microsoft's official reverse proxy, maintained alongside ASP.NET Core.
+It supports config-as-code via `LoadFromMemory()`, integrates with Aspire
+service discovery (`https+http://service-name`), and has no external
+dependencies.
+
+### Wolverine outbox over direct RabbitMQ
+
+Wolverine's PostgreSQL transactional outbox guarantees at-least-once delivery
+by writing events to the database within the same transaction as the domain
+operation. If RabbitMQ is temporarily unavailable, events are delivered
+automatically when it recovers.
+
+### One database per service
+
+Each microservice owns its PostgreSQL database. This enforces data isolation
+and allows independent schema evolution. Cross-service data access happens
+only through integration events or HTTP calls.
+
+### Shared.Hosting boundaries
+
+`Shared.Hosting` contains only cross-cutting infrastructure:
+
+- Granit Essentials (timing, security, validation, persistence, observability)
+- Wolverine + PostgreSQL outbox
+- JWT Bearer authentication
+- Redis caching
+- HTTP resilience
+
+Domain-specific modules (`Granit.Identity`, `Granit.Notifications`,
+`Granit.Authorization`) stay in each service's own module class. This prevents
+accidental coupling between services.
+
+## Communication patterns
+
+### Synchronous (HTTP)
+
+```text
+Client → API Gateway (YARP) → Service
+```
+
+- JWT validated at the gateway edge
+- Aspire service discovery resolves addresses
+- HTTP resilience (retry, circuit breaker, timeout) via `Granit.Http.Resilience`
+
+### Asynchronous (Integration Events)
+
+```text
+CatalogService → [PostgreSQL outbox] → RabbitMQ → NotificationService
+```
+
+- Events implement `IIntegrationEvent` (defined in `Shared`)
+- Published via `IDistributedEventBus` (Wolverine)
+- Stored in PostgreSQL outbox before RabbitMQ delivery
+- Handlers auto-discovered by Wolverine via convention
+
+### Distributed cache
+
+```text
+Any Service → Redis (via Granit.Caching.StackExchangeRedis)
+```
+
+## Module dependency graph
+
+```text
+AppHost
+  └── references all service projects (Aspire orchestration)
+
+ApiGateway
+  └── ServiceDefaults
+
+IdentityService / CatalogService / NotificationService
+  └── Shared.Hosting
+        ├── ServiceDefaults (OpenTelemetry, health checks)
+        └── Shared (integration event contracts)
+```
+
+## Health check probes
+
+Each service exposes three Kubernetes-compatible probes:
+
+| Probe | Path | Purpose |
+|-------|------|---------|
+| Liveness | `/health/live` | Is the process alive? |
+| Readiness | `/health/ready` | Can it serve traffic? |
+| Startup | `/health/startup` | Has it finished initializing? |
+
+## Infrastructure persistence
+
+All containers use `ContainerLifetime.Persistent` so data (PostgreSQL
+rows, Redis cache, RabbitMQ queues) survives AppHost restarts during
+development. Services use `WaitFor()` to avoid connection errors at startup.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,111 @@
+# Getting started
+
+## Prerequisites
+
+1. **.NET 10 SDK** — [download](https://dotnet.microsoft.com/download/dotnet/10.0)
+2. **Docker Desktop** — required for Aspire containers
+3. **GitHub Packages access** — configure NuGet credentials for `granit-fx`
+
+### Configure NuGet credentials
+
+```bash
+dotnet nuget add source \
+  https://nuget.pkg.github.com/granit-fx/index.json \
+  --name granit-registry \
+  --username YOUR_GITHUB_USERNAME \
+  --password YOUR_GITHUB_PAT \
+  --store-password-in-clear-text
+```
+
+Your PAT needs `read:packages` scope.
+
+## Scaffold a new solution
+
+```bash
+# Install the template (from local clone or NuGet)
+dotnet new install .
+
+# Create your solution
+dotnet new granit-microservice -n Acme.Platform -o ./acme-platform
+cd acme-platform
+```
+
+All files are renamed: `GranitMicroservice` becomes `Acme.Platform`.
+
+## Build and run
+
+```bash
+# Restore and build
+dotnet build Acme.Platform.slnx
+
+# Start everything via Aspire
+dotnet run --project src/Acme.Platform.AppHost
+```
+
+The Aspire dashboard opens at `https://localhost:17178`.
+
+## What starts automatically
+
+| Resource | Port | Notes |
+|----------|------|-------|
+| PostgreSQL | 5432 | 3 databases (identity, catalog, notification) |
+| PgAdmin | auto | PostgreSQL management UI |
+| Redis | 6379 | Distributed cache |
+| Redis Insight | auto | Redis management UI |
+| RabbitMQ | 5672 | Message broker |
+| RabbitMQ Management | 15672 | Queue management UI |
+| Keycloak | 8080 | Pre-configured realm with test users |
+| Identity Service | auto | User management |
+| Catalog Service | auto | Product CRUD + events |
+| Notification Service | auto | Event-driven notifications |
+| API Gateway | auto | Single entry point |
+
+All containers use `ContainerLifetime.Persistent` — data survives
+AppHost restarts.
+
+## Test users (Keycloak)
+
+| Username | Password | Roles |
+|----------|----------|-------|
+| `admin` | `admin` | admin, user |
+| `testuser` | `test` | user |
+
+Keycloak admin console: `http://localhost:8080` (admin/admin).
+
+## Run tests
+
+```bash
+# Unit tests
+dotnet test Acme.Platform.slnx --filter "FullyQualifiedName!~Integration"
+
+# Integration tests (requires Docker)
+dotnet test Acme.Platform.slnx --filter "FullyQualifiedName~Integration"
+```
+
+## Project structure
+
+```text
+acme-platform/
+├── src/
+│   ├── Acme.Platform.AppHost/            # Aspire orchestration
+│   ├── Acme.Platform.ServiceDefaults/    # Shared infra (OTel, health)
+│   ├── Acme.Platform.Shared/             # Integration event contracts
+│   ├── Acme.Platform.Shared.Hosting/     # Cross-cutting Granit config
+│   ├── Acme.Platform.ApiGateway/         # YARP reverse proxy
+│   ├── Acme.Platform.IdentityService/    # Keycloak + Granit.Identity
+│   ├── Acme.Platform.CatalogService/     # Domain + endpoints + events
+│   └── Acme.Platform.NotificationService/ # Event-driven handlers
+├── tests/
+│   ├── Acme.Platform.CatalogService.Tests/
+│   ├── Acme.Platform.CatalogService.Tests.Integration/
+│   ├── Acme.Platform.IdentityService.Tests/
+│   └── Acme.Platform.NotificationService.Tests/
+└── infra/keycloak-realms/                 # Keycloak realm config
+```
+
+## Next steps
+
+- Add domain entities to CatalogService
+- Add Wolverine handlers for new integration events
+- Configure production Keycloak (replace dev secrets)
+- Add EF Core migrations: `dotnet ef migrations add Init -p src/Acme.Platform.CatalogService`

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.103",
+    "rollForward": "latestFeature"
+  }
+}

--- a/infra/keycloak-realms/granit-realm.json
+++ b/infra/keycloak-realms/granit-realm.json
@@ -1,0 +1,135 @@
+{
+  "realm": "granit",
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": true,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": true,
+  "roles": {
+    "realm": [
+      {
+        "name": "admin",
+        "description": "Administrator role with full access"
+      },
+      {
+        "name": "user",
+        "description": "Standard user role"
+      }
+    ]
+  },
+  "clients": [
+    {
+      "clientId": "granit-gateway",
+      "name": "Granit API Gateway",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "gateway-secret-change-in-production",
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": false,
+      "redirectUris": [
+        "https://localhost:*/*"
+      ],
+      "webOrigins": [
+        "https://localhost"
+      ],
+      "defaultClientScopes": [
+        "openid",
+        "profile",
+        "email",
+        "roles"
+      ]
+    },
+    {
+      "clientId": "granit-spa",
+      "name": "Granit SPA Client",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "directAccessGrantsEnabled": true,
+      "redirectUris": [
+        "http://localhost:*/*",
+        "https://localhost:*/*"
+      ],
+      "webOrigins": [
+        "http://localhost",
+        "https://localhost"
+      ],
+      "defaultClientScopes": [
+        "openid",
+        "profile",
+        "email",
+        "roles"
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "admin",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Admin",
+      "lastName": "User",
+      "email": "admin@granit.local",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "admin",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "admin",
+        "user"
+      ]
+    },
+    {
+      "username": "testuser",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Test",
+      "lastName": "User",
+      "email": "testuser@granit.local",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "user"
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "name": "roles",
+      "description": "OpenID Connect scope for roles",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true"
+      },
+      "protocolMappers": [
+        {
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="Granit GitHub" value="https://nuget.pkg.github.com/granit-fx/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="Granit GitHub">
+      <package pattern="Granit.*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -3,13 +3,13 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="Granit GitHub" value="https://nuget.pkg.github.com/granit-fx/index.json" />
+    <add key="granit-registry" value="https://nuget.pkg.github.com/granit-fx/index.json" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="nuget.org">
       <package pattern="*" />
     </packageSource>
-    <packageSource key="Granit GitHub">
+    <packageSource key="granit-registry">
       <package pattern="Granit.*" />
     </packageSource>
   </packageSourceMapping>

--- a/src/GranitMicroservice.ApiGateway/GranitMicroservice.ApiGateway.csproj
+++ b/src/GranitMicroservice.ApiGateway/GranitMicroservice.ApiGateway.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <ItemGroup>
+    <ProjectReference Include="..\GranitMicroservice.ServiceDefaults\GranitMicroservice.ServiceDefaults.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/GranitMicroservice.ApiGateway/GranitMicroservice.ApiGateway.csproj
+++ b/src/GranitMicroservice.ApiGateway/GranitMicroservice.ApiGateway.csproj
@@ -1,6 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Scalar.AspNetCore" />
+    <PackageReference Include="Yarp.ReverseProxy" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\GranitMicroservice.ServiceDefaults\GranitMicroservice.ServiceDefaults.csproj" />
   </ItemGroup>
 

--- a/src/GranitMicroservice.ApiGateway/Program.cs
+++ b/src/GranitMicroservice.ApiGateway/Program.cs
@@ -1,13 +1,56 @@
 using System.Threading.RateLimiting;
 using GranitMicroservice.ServiceDefaults;
 using Scalar.AspNetCore;
+using Yarp.ReverseProxy.Configuration;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
 
 builder.Services.AddReverseProxy()
-    .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
+    .LoadFromMemory(
+    [
+        new RouteConfig
+        {
+            RouteId = "catalog",
+            ClusterId = "catalog",
+            AuthorizationPolicy = "default",
+            Match = new RouteMatch { Path = "/api/catalog/{**catch-all}" },
+            Transforms =
+            [
+                new Dictionary<string, string> { ["PathRemovePrefix"] = "/api/catalog" },
+            ],
+        },
+        new RouteConfig
+        {
+            RouteId = "identity",
+            ClusterId = "identity",
+            AuthorizationPolicy = "default",
+            Match = new RouteMatch { Path = "/api/identity/{**catch-all}" },
+            Transforms =
+            [
+                new Dictionary<string, string> { ["PathRemovePrefix"] = "/api/identity" },
+            ],
+        },
+    ],
+    [
+        new ClusterConfig
+        {
+            ClusterId = "catalog",
+            Destinations = new Dictionary<string, DestinationConfig>
+            {
+                ["default"] = new() { Address = "https+http://catalog-service" },
+            },
+        },
+        new ClusterConfig
+        {
+            ClusterId = "identity",
+            Destinations = new Dictionary<string, DestinationConfig>
+            {
+                ["default"] = new() { Address = "https+http://identity-service" },
+            },
+        },
+    ]);
 
 builder.Services.AddAuthentication("Bearer")
     .AddJwtBearer("Bearer", options =>
@@ -19,6 +62,8 @@ builder.Services.AddAuthentication("Bearer")
 
 builder.Services.AddAuthorization();
 builder.Services.AddOpenApi();
+builder.Services.AddHttpClient("catalog", c => c.BaseAddress = new Uri("https+http://catalog-service"));
+builder.Services.AddHttpClient("identity", c => c.BaseAddress = new Uri("https+http://identity-service"));
 
 builder.Services.AddRateLimiter(options =>
 {
@@ -44,7 +89,28 @@ app.UseAuthorization();
 app.UseRateLimiter();
 
 app.MapReverseProxy();
+
+// OpenAPI aggregation — proxy each service's spec
+app.MapGet("/openapi/catalog.json", async (IHttpClientFactory factory) =>
+{
+    var client = factory.CreateClient("catalog");
+    var spec = await client.GetStringAsync("/openapi/v1.json");
+    return Results.Content(spec, "application/json");
+}).ExcludeFromDescription();
+
+app.MapGet("/openapi/identity.json", async (IHttpClientFactory factory) =>
+{
+    var client = factory.CreateClient("identity");
+    var spec = await client.GetStringAsync("/openapi/v1.json");
+    return Results.Content(spec, "application/json");
+}).ExcludeFromDescription();
+
 app.MapOpenApi();
-app.MapScalarApiReference();
+app.MapScalarApiReference(options =>
+{
+    options.Title = "GranitMicroservice API";
+    options.AddDocument("Catalog", "/openapi/catalog.json");
+    options.AddDocument("Identity", "/openapi/identity.json");
+});
 
 await app.RunAsync();

--- a/src/GranitMicroservice.ApiGateway/Program.cs
+++ b/src/GranitMicroservice.ApiGateway/Program.cs
@@ -1,0 +1,12 @@
+using GranitMicroservice.ServiceDefaults;
+
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+builder.AddServiceDefaults();
+
+WebApplication app = builder.Build();
+
+app.MapDefaultEndpoints();
+app.MapGet("/", () => new { Service = "ApiGateway" });
+
+await app.RunAsync();

--- a/src/GranitMicroservice.ApiGateway/Program.cs
+++ b/src/GranitMicroservice.ApiGateway/Program.cs
@@ -1,12 +1,50 @@
+using System.Threading.RateLimiting;
 using GranitMicroservice.ServiceDefaults;
+using Scalar.AspNetCore;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
 
+builder.Services.AddReverseProxy()
+    .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
+
+builder.Services.AddAuthentication("Bearer")
+    .AddJwtBearer("Bearer", options =>
+    {
+        options.Authority = builder.Configuration["Authentication:Authority"];
+        options.Audience = builder.Configuration["Authentication:Audience"];
+        options.RequireHttpsMetadata = false; // dev only — Aspire manages TLS
+    });
+
+builder.Services.AddAuthorization();
+builder.Services.AddOpenApi();
+
+builder.Services.AddRateLimiter(options =>
+{
+    options.AddPolicy("default", context =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 100,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 10,
+            }));
+
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+});
+
 WebApplication app = builder.Build();
 
 app.MapDefaultEndpoints();
-app.MapGet("/", () => new { Service = "ApiGateway" });
+
+app.UseAuthentication();
+app.UseAuthorization();
+app.UseRateLimiter();
+
+app.MapReverseProxy();
+app.MapOpenApi();
+app.MapScalarApiReference();
 
 await app.RunAsync();

--- a/src/GranitMicroservice.ApiGateway/Properties/launchSettings.json
+++ b/src/GranitMicroservice.ApiGateway/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "applicationUrl": "http://localhost:5100",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/GranitMicroservice.ApiGateway/appsettings.Development.json
+++ b/src/GranitMicroservice.ApiGateway/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/GranitMicroservice.ApiGateway/appsettings.json
+++ b/src/GranitMicroservice.ApiGateway/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/GranitMicroservice.ApiGateway/appsettings.json
+++ b/src/GranitMicroservice.ApiGateway/appsettings.json
@@ -9,51 +9,5 @@
   "Authentication": {
     "Authority": "http://localhost:8080/realms/granit",
     "Audience": "granit-gateway"
-  },
-  "ReverseProxy": {
-    "Routes": {
-      "identity-route": {
-        "ClusterId": "identity-cluster",
-        "AuthorizationPolicy": "default",
-        "Match": {
-          "Path": "/api/identity/{**catch-all}"
-        },
-        "Transforms": [
-          { "PathRemovePrefix": "/api/identity" }
-        ]
-      },
-      "catalog-route": {
-        "ClusterId": "catalog-cluster",
-        "AuthorizationPolicy": "default",
-        "Match": {
-          "Path": "/api/catalog/{**catch-all}"
-        },
-        "Transforms": [
-          { "PathRemovePrefix": "/api/catalog" }
-        ]
-      },
-      "health-route": {
-        "ClusterId": "gateway-self",
-        "Match": {
-          "Path": "/health/{**catch-all}"
-        }
-      }
-    },
-    "Clusters": {
-      "identity-cluster": {
-        "Destinations": {
-          "destination1": {
-            "Address": "https+http://identity-service"
-          }
-        }
-      },
-      "catalog-cluster": {
-        "Destinations": {
-          "destination1": {
-            "Address": "https+http://catalog-service"
-          }
-        }
-      }
-    }
   }
 }

--- a/src/GranitMicroservice.ApiGateway/appsettings.json
+++ b/src/GranitMicroservice.ApiGateway/appsettings.json
@@ -2,7 +2,58 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Yarp": "Information"
+    }
+  },
+  "Authentication": {
+    "Authority": "http://localhost:8080/realms/granit",
+    "Audience": "granit-gateway"
+  },
+  "ReverseProxy": {
+    "Routes": {
+      "identity-route": {
+        "ClusterId": "identity-cluster",
+        "AuthorizationPolicy": "default",
+        "Match": {
+          "Path": "/api/identity/{**catch-all}"
+        },
+        "Transforms": [
+          { "PathRemovePrefix": "/api/identity" }
+        ]
+      },
+      "catalog-route": {
+        "ClusterId": "catalog-cluster",
+        "AuthorizationPolicy": "default",
+        "Match": {
+          "Path": "/api/catalog/{**catch-all}"
+        },
+        "Transforms": [
+          { "PathRemovePrefix": "/api/catalog" }
+        ]
+      },
+      "health-route": {
+        "ClusterId": "gateway-self",
+        "Match": {
+          "Path": "/health/{**catch-all}"
+        }
+      }
+    },
+    "Clusters": {
+      "identity-cluster": {
+        "Destinations": {
+          "destination1": {
+            "Address": "https+http://identity-service"
+          }
+        }
+      },
+      "catalog-cluster": {
+        "Destinations": {
+          "destination1": {
+            "Address": "https+http://catalog-service"
+          }
+        }
+      }
     }
   }
 }

--- a/src/GranitMicroservice.AppHost/GranitMicroservice.AppHost.csproj
+++ b/src/GranitMicroservice.AppHost/GranitMicroservice.AppHost.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.2.0" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.1.2" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/GranitMicroservice.AppHost/GranitMicroservice.AppHost.csproj
+++ b/src/GranitMicroservice.AppHost/GranitMicroservice.AppHost.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Aspire.Hosting.PostgreSQL" />
     <PackageReference Include="Aspire.Hosting.Redis" />
     <PackageReference Include="Aspire.Hosting.RabbitMQ" />
+    <PackageReference Include="Aspire.Hosting.Keycloak" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GranitMicroservice.AppHost/GranitMicroservice.AppHost.csproj
+++ b/src/GranitMicroservice.AppHost/GranitMicroservice.AppHost.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.2.0" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsAspireHost>true</IsAspireHost>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" />
+    <PackageReference Include="Aspire.Hosting.Redis" />
+    <PackageReference Include="Aspire.Hosting.RabbitMQ" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GranitMicroservice.ApiGateway\GranitMicroservice.ApiGateway.csproj" />
+    <ProjectReference Include="..\GranitMicroservice.CatalogService\GranitMicroservice.CatalogService.csproj" />
+    <ProjectReference Include="..\GranitMicroservice.IdentityService\GranitMicroservice.IdentityService.csproj" />
+    <ProjectReference Include="..\GranitMicroservice.NotificationService\GranitMicroservice.NotificationService.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/GranitMicroservice.AppHost/Program.cs
+++ b/src/GranitMicroservice.AppHost/Program.cs
@@ -1,0 +1,56 @@
+IDistributedApplicationBuilder builder = DistributedApplication.CreateBuilder(args);
+
+// Infrastructure
+var postgres = builder.AddPostgres("postgres");
+var identityDb = postgres.AddDatabase("identity-db");
+var catalogDb = postgres.AddDatabase("catalog-db");
+var notificationDb = postgres.AddDatabase("notification-db");
+
+var redis = builder.AddRedis("redis");
+
+var rabbitmq = builder.AddRabbitMQ("rabbitmq")
+    .WithManagementPlugin();
+
+var keycloak = builder.AddContainer("keycloak", "quay.io/keycloak/keycloak", "26.2")
+    .WithArgs("start-dev", "--import-realm")
+    .WithBindMount("../../infra/keycloak-realms", "/opt/keycloak/data/import")
+    .WithHttpEndpoint(port: 8080, targetPort: 8080, name: "http")
+    .WithEnvironment("KC_HEALTH_ENABLED", "true")
+    .WithEnvironment("KEYCLOAK_ADMIN", "admin")
+    .WithEnvironment("KEYCLOAK_ADMIN_PASSWORD", "admin");
+
+// Services
+var identityService = builder.AddProject<Projects.GranitMicroservice_IdentityService>("identity-service")
+    .WithReference(identityDb)
+    .WithReference(redis)
+    .WithReference(rabbitmq)
+    .WaitFor(identityDb)
+    .WaitFor(redis)
+    .WaitFor(rabbitmq)
+    .WaitFor(keycloak);
+
+var catalogService = builder.AddProject<Projects.GranitMicroservice_CatalogService>("catalog-service")
+    .WithReference(catalogDb)
+    .WithReference(redis)
+    .WithReference(rabbitmq)
+    .WaitFor(catalogDb)
+    .WaitFor(redis)
+    .WaitFor(rabbitmq);
+
+var notificationService = builder.AddProject<Projects.GranitMicroservice_NotificationService>("notification-service")
+    .WithReference(notificationDb)
+    .WithReference(redis)
+    .WithReference(rabbitmq)
+    .WaitFor(notificationDb)
+    .WaitFor(redis)
+    .WaitFor(rabbitmq);
+
+builder.AddProject<Projects.GranitMicroservice_ApiGateway>("api-gateway")
+    .WithReference(identityService)
+    .WithReference(catalogService)
+    .WithReference(redis)
+    .WaitFor(identityService)
+    .WaitFor(catalogService)
+    .WaitFor(keycloak);
+
+await builder.Build().RunAsync();

--- a/src/GranitMicroservice.AppHost/Program.cs
+++ b/src/GranitMicroservice.AppHost/Program.cs
@@ -1,31 +1,32 @@
 IDistributedApplicationBuilder builder = DistributedApplication.CreateBuilder(args);
 
-// Infrastructure
-var postgres = builder.AddPostgres("postgres");
+// Infrastructure — persistent containers survive AppHost restarts
+var postgres = builder.AddPostgres("postgres")
+    .WithLifetime(ContainerLifetime.Persistent)
+    .WithPgAdmin();
 var identityDb = postgres.AddDatabase("identity-db");
 var catalogDb = postgres.AddDatabase("catalog-db");
 var notificationDb = postgres.AddDatabase("notification-db");
 
-var redis = builder.AddRedis("redis");
+var redis = builder.AddRedis("redis")
+    .WithLifetime(ContainerLifetime.Persistent)
+    .WithRedisInsight();
 
-var rabbitmq = builder.AddRabbitMQ("rabbitmq")
+var rabbitmq = builder.AddRabbitMQ("messaging")
+    .WithLifetime(ContainerLifetime.Persistent)
     .WithManagementPlugin();
 
-var keycloak = builder.AddContainer("keycloak", "quay.io/keycloak/keycloak", "26.2")
-    .WithArgs("start-dev", "--import-realm")
-    .WithBindMount("../../infra/keycloak-realms", "/opt/keycloak/data/import")
-    .WithHttpEndpoint(port: 8080, targetPort: 8080, name: "http")
-    .WithEnvironment("KC_HEALTH_ENABLED", "true")
-    .WithEnvironment("KEYCLOAK_ADMIN", "admin")
-    .WithEnvironment("KEYCLOAK_ADMIN_PASSWORD", "admin");
+var keycloak = builder.AddKeycloak("keycloak", port: 8080)
+    .WithLifetime(ContainerLifetime.Persistent)
+    .WithDataVolume()
+    .WithRealmImport("../../infra/keycloak-realms");
 
-// Services
+// Services — WaitFor ensures infrastructure is ready before services start
 var identityService = builder.AddProject<Projects.GranitMicroservice_IdentityService>("identity-service")
     .WithReference(identityDb)
     .WithReference(redis)
     .WithReference(rabbitmq)
     .WaitFor(identityDb)
-    .WaitFor(redis)
     .WaitFor(rabbitmq)
     .WaitFor(keycloak);
 
@@ -34,7 +35,6 @@ var catalogService = builder.AddProject<Projects.GranitMicroservice_CatalogServi
     .WithReference(redis)
     .WithReference(rabbitmq)
     .WaitFor(catalogDb)
-    .WaitFor(redis)
     .WaitFor(rabbitmq);
 
 var notificationService = builder.AddProject<Projects.GranitMicroservice_NotificationService>("notification-service")
@@ -42,7 +42,6 @@ var notificationService = builder.AddProject<Projects.GranitMicroservice_Notific
     .WithReference(redis)
     .WithReference(rabbitmq)
     .WaitFor(notificationDb)
-    .WaitFor(redis)
     .WaitFor(rabbitmq);
 
 builder.AddProject<Projects.GranitMicroservice_ApiGateway>("api-gateway")

--- a/src/GranitMicroservice.AppHost/Properties/launchSettings.json
+++ b/src/GranitMicroservice.AppHost/Properties/launchSettings.json
@@ -1,0 +1,16 @@
+{
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17178;http://localhost:15178",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21178",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22178"
+      }
+    }
+  }
+}

--- a/src/GranitMicroservice.AppHost/appsettings.Development.json
+++ b/src/GranitMicroservice.AppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/GranitMicroservice.AppHost/appsettings.json
+++ b/src/GranitMicroservice.AppHost/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
+    }
+  }
+}

--- a/src/GranitMicroservice.CatalogService/CatalogServiceModule.cs
+++ b/src/GranitMicroservice.CatalogService/CatalogServiceModule.cs
@@ -1,0 +1,17 @@
+using Granit.Core.Modularity;
+using Granit.Persistence;
+using Granit.Persistence.Migrations;
+using Granit.Validation;
+using Granit.Validation.Extensions;
+
+namespace GranitMicroservice.CatalogService;
+
+[DependsOn(
+    typeof(GranitPersistenceModule),
+    typeof(GranitPersistenceMigrationsModule),
+    typeof(GranitValidationModule))]
+public sealed class CatalogServiceModule : GranitModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.AddGranitValidatorsFromAssemblyContaining<CatalogServiceModule>();
+}

--- a/src/GranitMicroservice.CatalogService/Domain/Category.cs
+++ b/src/GranitMicroservice.CatalogService/Domain/Category.cs
@@ -1,0 +1,12 @@
+using Granit.Core.Domain;
+
+namespace GranitMicroservice.CatalogService.Domain;
+
+public sealed class Category : AuditedEntity
+{
+    public required string Name { get; set; }
+
+    public string? Description { get; set; }
+
+    public List<Product> Products { get; set; } = [];
+}

--- a/src/GranitMicroservice.CatalogService/Domain/Product.cs
+++ b/src/GranitMicroservice.CatalogService/Domain/Product.cs
@@ -1,0 +1,16 @@
+using Granit.Core.Domain;
+
+namespace GranitMicroservice.CatalogService.Domain;
+
+public sealed class Product : FullAuditedEntity
+{
+    public required string Name { get; set; }
+
+    public string? Description { get; set; }
+
+    public decimal Price { get; set; }
+
+    public Guid CategoryId { get; set; }
+
+    public Category? Category { get; set; }
+}

--- a/src/GranitMicroservice.CatalogService/Endpoints/CatalogProductRequest.cs
+++ b/src/GranitMicroservice.CatalogService/Endpoints/CatalogProductRequest.cs
@@ -1,0 +1,13 @@
+namespace GranitMicroservice.CatalogService.Endpoints;
+
+public sealed record CreateCatalogProductRequest(
+    string Name,
+    string? Description,
+    decimal Price,
+    Guid CategoryId);
+
+public sealed record UpdateCatalogProductRequest(
+    string Name,
+    string? Description,
+    decimal Price,
+    Guid CategoryId);

--- a/src/GranitMicroservice.CatalogService/Endpoints/CatalogProductResponse.cs
+++ b/src/GranitMicroservice.CatalogService/Endpoints/CatalogProductResponse.cs
@@ -1,0 +1,11 @@
+namespace GranitMicroservice.CatalogService.Endpoints;
+
+public sealed record CatalogProductResponse(
+    Guid Id,
+    string Name,
+    string? Description,
+    decimal Price,
+    Guid CategoryId,
+    string? CategoryName,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset? ModifiedAt);

--- a/src/GranitMicroservice.CatalogService/Endpoints/ProductEndpoints.cs
+++ b/src/GranitMicroservice.CatalogService/Endpoints/ProductEndpoints.cs
@@ -1,0 +1,166 @@
+using Granit.Core.Events;
+using GranitMicroservice.CatalogService.Domain;
+using GranitMicroservice.CatalogService.Persistence;
+using GranitMicroservice.Shared.Events;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.EntityFrameworkCore;
+
+namespace GranitMicroservice.CatalogService.Endpoints;
+
+public static class ProductEndpoints
+{
+    public static RouteGroupBuilder MapProductEndpoints(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/products")
+            .WithTags("Products")
+            .RequireAuthorization();
+
+        group.MapGet("/", GetProducts);
+        group.MapGet("/{id:guid}", GetProduct);
+        group.MapPost("/", CreateProduct);
+        group.MapPut("/{id:guid}", UpdateProduct);
+        group.MapDelete("/{id:guid}", DeleteProduct);
+
+        return group;
+    }
+
+    private static async Task<Ok<List<CatalogProductResponse>>> GetProducts(
+        CatalogDbContext db,
+        CancellationToken cancellationToken,
+        int skip = 0,
+        int take = 20)
+    {
+        var products = await db.Products
+            .Include(p => p.Category)
+            .OrderBy(p => p.Name)
+            .Skip(skip)
+            .Take(take)
+            .Select(p => MapToResponse(p))
+            .ToListAsync(cancellationToken);
+
+        return TypedResults.Ok(products);
+    }
+
+    private static async Task<Results<Ok<CatalogProductResponse>, ProblemHttpResult>> GetProduct(
+        Guid id,
+        CatalogDbContext db,
+        CancellationToken cancellationToken)
+    {
+        var product = await db.Products
+            .Include(p => p.Category)
+            .FirstOrDefaultAsync(p => p.Id == id, cancellationToken);
+
+        if (product is null)
+        {
+            return TypedResults.Problem(
+                detail: $"Product with id '{id}' not found.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
+        return TypedResults.Ok(MapToResponse(product));
+    }
+
+    private static async Task<Results<Created<CatalogProductResponse>, ProblemHttpResult>> CreateProduct(
+        CreateCatalogProductRequest request,
+        CatalogDbContext db,
+        IDistributedEventBus eventBus,
+        CancellationToken cancellationToken)
+    {
+        var categoryExists = await db.Categories
+            .AnyAsync(c => c.Id == request.CategoryId, cancellationToken);
+
+        if (!categoryExists)
+        {
+            return TypedResults.Problem(
+                detail: $"Category with id '{request.CategoryId}' not found.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var product = new Product
+        {
+            Name = request.Name,
+            Description = request.Description,
+            Price = request.Price,
+            CategoryId = request.CategoryId,
+        };
+
+        db.Products.Add(product);
+        await db.SaveChangesAsync(cancellationToken);
+
+        await eventBus.PublishAsync(
+            new CatalogProductCreatedEvent(product.Id, product.Name, product.Price),
+            cancellationToken);
+
+        var created = await db.Products
+            .Include(p => p.Category)
+            .FirstAsync(p => p.Id == product.Id, cancellationToken);
+
+        return TypedResults.Created(
+            $"/api/products/{created.Id}",
+            MapToResponse(created));
+    }
+
+    private static async Task<Results<Ok<CatalogProductResponse>, ProblemHttpResult>> UpdateProduct(
+        Guid id,
+        UpdateCatalogProductRequest request,
+        CatalogDbContext db,
+        IDistributedEventBus eventBus,
+        CancellationToken cancellationToken)
+    {
+        var product = await db.Products
+            .Include(p => p.Category)
+            .FirstOrDefaultAsync(p => p.Id == id, cancellationToken);
+
+        if (product is null)
+        {
+            return TypedResults.Problem(
+                detail: $"Product with id '{id}' not found.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
+        product.Name = request.Name;
+        product.Description = request.Description;
+        product.Price = request.Price;
+        product.CategoryId = request.CategoryId;
+
+        await db.SaveChangesAsync(cancellationToken);
+
+        await eventBus.PublishAsync(
+            new CatalogProductUpdatedEvent(product.Id, product.Name, product.Price),
+            cancellationToken);
+
+        return TypedResults.Ok(MapToResponse(product));
+    }
+
+    private static async Task<Results<NoContent, ProblemHttpResult>> DeleteProduct(
+        Guid id,
+        CatalogDbContext db,
+        CancellationToken cancellationToken)
+    {
+        var product = await db.Products
+            .FirstOrDefaultAsync(p => p.Id == id, cancellationToken);
+
+        if (product is null)
+        {
+            return TypedResults.Problem(
+                detail: $"Product with id '{id}' not found.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
+        db.Products.Remove(product);
+        await db.SaveChangesAsync(cancellationToken);
+
+        return TypedResults.NoContent();
+    }
+
+    private static CatalogProductResponse MapToResponse(Product product) =>
+        new(
+            product.Id,
+            product.Name,
+            product.Description,
+            product.Price,
+            product.CategoryId,
+            product.Category?.Name,
+            product.CreatedAt,
+            product.ModifiedAt);
+}

--- a/src/GranitMicroservice.CatalogService/GranitMicroservice.CatalogService.csproj
+++ b/src/GranitMicroservice.CatalogService/GranitMicroservice.CatalogService.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <ItemGroup>
+    <ProjectReference Include="..\GranitMicroservice.ServiceDefaults\GranitMicroservice.ServiceDefaults.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/GranitMicroservice.CatalogService/GranitMicroservice.CatalogService.csproj
+++ b/src/GranitMicroservice.CatalogService/GranitMicroservice.CatalogService.csproj
@@ -1,7 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <ItemGroup>
-    <ProjectReference Include="..\GranitMicroservice.ServiceDefaults\GranitMicroservice.ServiceDefaults.csproj" />
+    <PackageReference Include="Granit.Persistence" />
+    <PackageReference Include="Granit.Persistence.Migrations" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Scalar.AspNetCore" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GranitMicroservice.Shared.Hosting\GranitMicroservice.Shared.Hosting.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/GranitMicroservice.CatalogService/Persistence/CatalogDbContext.cs
+++ b/src/GranitMicroservice.CatalogService/Persistence/CatalogDbContext.cs
@@ -1,0 +1,24 @@
+using Granit.Core.DataFiltering;
+using Granit.Core.MultiTenancy;
+using Granit.Persistence.Extensions;
+using GranitMicroservice.CatalogService.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace GranitMicroservice.CatalogService.Persistence;
+
+public sealed class CatalogDbContext(
+    DbContextOptions<CatalogDbContext> options,
+    ICurrentTenant? currentTenant = null,
+    IDataFilter? dataFilter = null) : DbContext(options)
+{
+    public DbSet<Product> Products => Set<Product>();
+
+    public DbSet<Category> Categories => Set<Category>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(CatalogDbContext).Assembly);
+        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
+    }
+}

--- a/src/GranitMicroservice.CatalogService/Persistence/Configurations/CategoryConfiguration.cs
+++ b/src/GranitMicroservice.CatalogService/Persistence/Configurations/CategoryConfiguration.cs
@@ -1,0 +1,20 @@
+using GranitMicroservice.CatalogService.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace GranitMicroservice.CatalogService.Persistence.Configurations;
+
+public sealed class CategoryConfiguration : IEntityTypeConfiguration<Category>
+{
+    public void Configure(EntityTypeBuilder<Category> builder)
+    {
+        builder.ToTable("Categories");
+
+        builder.Property(c => c.Name)
+            .IsRequired()
+            .HasMaxLength(128);
+
+        builder.Property(c => c.Description)
+            .HasMaxLength(1000);
+    }
+}

--- a/src/GranitMicroservice.CatalogService/Persistence/Configurations/ProductConfiguration.cs
+++ b/src/GranitMicroservice.CatalogService/Persistence/Configurations/ProductConfiguration.cs
@@ -1,0 +1,28 @@
+using GranitMicroservice.CatalogService.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace GranitMicroservice.CatalogService.Persistence.Configurations;
+
+public sealed class ProductConfiguration : IEntityTypeConfiguration<Product>
+{
+    public void Configure(EntityTypeBuilder<Product> builder)
+    {
+        builder.ToTable("Products");
+
+        builder.Property(p => p.Name)
+            .IsRequired()
+            .HasMaxLength(256);
+
+        builder.Property(p => p.Description)
+            .HasMaxLength(2000);
+
+        builder.Property(p => p.Price)
+            .HasPrecision(18, 2);
+
+        builder.HasOne(p => p.Category)
+            .WithMany(c => c.Products)
+            .HasForeignKey(p => p.CategoryId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/GranitMicroservice.CatalogService/Program.cs
+++ b/src/GranitMicroservice.CatalogService/Program.cs
@@ -1,12 +1,37 @@
+using Granit.Core.Extensions;
+using Granit.Persistence.Interceptors;
+using GranitMicroservice.CatalogService;
+using GranitMicroservice.CatalogService.Endpoints;
+using GranitMicroservice.CatalogService.Persistence;
 using GranitMicroservice.ServiceDefaults;
+using GranitMicroservice.Shared.Hosting.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Scalar.AspNetCore;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
-builder.AddServiceDefaults();
+await builder.AddSharedHostingAsync();
+
+await builder.AddGranitAsync(granit => granit
+    .AddModule<CatalogServiceModule>());
+
+builder.Services.AddDbContextFactory<CatalogDbContext>((sp, options) =>
+{
+    options.UseNpgsql(builder.Configuration.GetConnectionString("catalog-db"));
+    options.AddInterceptors(
+        sp.GetRequiredService<AuditedEntityInterceptor>(),
+        sp.GetRequiredService<SoftDeleteInterceptor>());
+});
+
+builder.Services.AddOpenApi();
 
 WebApplication app = builder.Build();
 
+await app.UseGranitAsync();
+
 app.MapDefaultEndpoints();
-app.MapGet("/", () => new { Service = "CatalogService" });
+app.MapOpenApi();
+app.MapScalarApiReference();
+app.MapProductEndpoints();
 
 await app.RunAsync();

--- a/src/GranitMicroservice.CatalogService/Program.cs
+++ b/src/GranitMicroservice.CatalogService/Program.cs
@@ -1,0 +1,12 @@
+using GranitMicroservice.ServiceDefaults;
+
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+builder.AddServiceDefaults();
+
+WebApplication app = builder.Build();
+
+app.MapDefaultEndpoints();
+app.MapGet("/", () => new { Service = "CatalogService" });
+
+await app.RunAsync();

--- a/src/GranitMicroservice.CatalogService/Properties/launchSettings.json
+++ b/src/GranitMicroservice.CatalogService/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "applicationUrl": "http://localhost:5120",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/GranitMicroservice.CatalogService/Validators/CreateCatalogProductValidator.cs
+++ b/src/GranitMicroservice.CatalogService/Validators/CreateCatalogProductValidator.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+using GranitMicroservice.CatalogService.Endpoints;
+
+namespace GranitMicroservice.CatalogService.Validators;
+
+public sealed class CreateCatalogProductValidator : AbstractValidator<CreateCatalogProductRequest>
+{
+    public CreateCatalogProductValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(256);
+
+        RuleFor(x => x.Price)
+            .GreaterThanOrEqualTo(0);
+
+        RuleFor(x => x.CategoryId)
+            .NotEmpty();
+    }
+}

--- a/src/GranitMicroservice.CatalogService/Validators/UpdateCatalogProductValidator.cs
+++ b/src/GranitMicroservice.CatalogService/Validators/UpdateCatalogProductValidator.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+using GranitMicroservice.CatalogService.Endpoints;
+
+namespace GranitMicroservice.CatalogService.Validators;
+
+public sealed class UpdateCatalogProductValidator : AbstractValidator<UpdateCatalogProductRequest>
+{
+    public UpdateCatalogProductValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(256);
+
+        RuleFor(x => x.Price)
+            .GreaterThanOrEqualTo(0);
+
+        RuleFor(x => x.CategoryId)
+            .NotEmpty();
+    }
+}

--- a/src/GranitMicroservice.CatalogService/appsettings.Development.json
+++ b/src/GranitMicroservice.CatalogService/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/GranitMicroservice.CatalogService/appsettings.json
+++ b/src/GranitMicroservice.CatalogService/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/GranitMicroservice.IdentityService/GranitMicroservice.IdentityService.csproj
+++ b/src/GranitMicroservice.IdentityService/GranitMicroservice.IdentityService.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <ItemGroup>
+    <ProjectReference Include="..\GranitMicroservice.ServiceDefaults\GranitMicroservice.ServiceDefaults.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/GranitMicroservice.IdentityService/GranitMicroservice.IdentityService.csproj
+++ b/src/GranitMicroservice.IdentityService/GranitMicroservice.IdentityService.csproj
@@ -1,7 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <ItemGroup>
-    <ProjectReference Include="..\GranitMicroservice.ServiceDefaults\GranitMicroservice.ServiceDefaults.csproj" />
+    <PackageReference Include="Granit.Authentication.Keycloak" />
+    <PackageReference Include="Granit.Authorization" />
+    <PackageReference Include="Granit.Identity" />
+    <PackageReference Include="Granit.Identity.Keycloak" />
+    <PackageReference Include="Granit.Identity.EntityFrameworkCore" />
+    <PackageReference Include="Granit.Identity.Endpoints" />
+    <PackageReference Include="Granit.Persistence" />
+    <PackageReference Include="Granit.Persistence.Migrations" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Scalar.AspNetCore" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GranitMicroservice.Shared.Hosting\GranitMicroservice.Shared.Hosting.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/GranitMicroservice.IdentityService/IdentityServiceModule.cs
+++ b/src/GranitMicroservice.IdentityService/IdentityServiceModule.cs
@@ -1,0 +1,24 @@
+using Granit.Authentication.JwtBearer;
+using Granit.Authentication.Keycloak;
+using Granit.Authorization;
+using Granit.Core.Modularity;
+using Granit.Identity;
+using Granit.Identity.Endpoints;
+using Granit.Identity.EntityFrameworkCore;
+using Granit.Identity.Keycloak;
+using Granit.Persistence;
+using Granit.Persistence.Migrations;
+
+namespace GranitMicroservice.IdentityService;
+
+[DependsOn(
+    typeof(GranitAuthenticationKeycloakModule),
+    typeof(GranitAuthorizationModule),
+    typeof(GranitIdentityModule),
+    typeof(GranitIdentityEndpointsModule),
+    typeof(GranitIdentityEntityFrameworkCoreModule),
+    typeof(GranitIdentityKeycloakModule),
+    typeof(GranitJwtBearerModule),
+    typeof(GranitPersistenceModule),
+    typeof(GranitPersistenceMigrationsModule))]
+public sealed class IdentityServiceModule : GranitModule;

--- a/src/GranitMicroservice.IdentityService/Persistence/IdentityServiceDbContext.cs
+++ b/src/GranitMicroservice.IdentityService/Persistence/IdentityServiceDbContext.cs
@@ -1,0 +1,23 @@
+using Granit.Core.DataFiltering;
+using Granit.Core.MultiTenancy;
+using Granit.Identity.EntityFrameworkCore.DbContext;
+using Granit.Identity.EntityFrameworkCore.Entities;
+using Granit.Persistence.Extensions;
+using Microsoft.EntityFrameworkCore;
+
+namespace GranitMicroservice.IdentityService.Persistence;
+
+public sealed class IdentityServiceDbContext(
+    DbContextOptions<IdentityServiceDbContext> options,
+    ICurrentTenant? currentTenant = null,
+    IDataFilter? dataFilter = null) : DbContext(options), IUserCacheDbContext
+{
+    public DbSet<UserCacheEntry> UserCacheEntries => Set<UserCacheEntry>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(IdentityServiceDbContext).Assembly);
+        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
+    }
+}

--- a/src/GranitMicroservice.IdentityService/Program.cs
+++ b/src/GranitMicroservice.IdentityService/Program.cs
@@ -1,0 +1,12 @@
+using GranitMicroservice.ServiceDefaults;
+
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+builder.AddServiceDefaults();
+
+WebApplication app = builder.Build();
+
+app.MapDefaultEndpoints();
+app.MapGet("/", () => new { Service = "IdentityService" });
+
+await app.RunAsync();

--- a/src/GranitMicroservice.IdentityService/Program.cs
+++ b/src/GranitMicroservice.IdentityService/Program.cs
@@ -1,12 +1,37 @@
+using Granit.Core.Extensions;
+using Granit.Identity.EntityFrameworkCore.Extensions;
+using Granit.Persistence.Interceptors;
+using GranitMicroservice.IdentityService;
+using GranitMicroservice.IdentityService.Persistence;
 using GranitMicroservice.ServiceDefaults;
+using GranitMicroservice.Shared.Hosting.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Scalar.AspNetCore;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
-builder.AddServiceDefaults();
+await builder.AddSharedHostingAsync();
+
+await builder.AddGranitAsync(granit => granit
+    .AddModule<IdentityServiceModule>());
+
+builder.Services.AddDbContextFactory<IdentityServiceDbContext>((sp, options) =>
+{
+    options.UseNpgsql(builder.Configuration.GetConnectionString("identity-db"));
+    options.AddInterceptors(
+        sp.GetRequiredService<AuditedEntityInterceptor>());
+});
+
+builder.Services.AddGranitIdentityEntityFrameworkCore<IdentityServiceDbContext>();
+
+builder.Services.AddOpenApi();
 
 WebApplication app = builder.Build();
 
+await app.UseGranitAsync();
+
 app.MapDefaultEndpoints();
-app.MapGet("/", () => new { Service = "IdentityService" });
+app.MapOpenApi();
+app.MapScalarApiReference();
 
 await app.RunAsync();

--- a/src/GranitMicroservice.IdentityService/Properties/launchSettings.json
+++ b/src/GranitMicroservice.IdentityService/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "applicationUrl": "http://localhost:5110",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/GranitMicroservice.IdentityService/appsettings.Development.json
+++ b/src/GranitMicroservice.IdentityService/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/GranitMicroservice.IdentityService/appsettings.json
+++ b/src/GranitMicroservice.IdentityService/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/GranitMicroservice.IdentityService/appsettings.json
+++ b/src/GranitMicroservice.IdentityService/appsettings.json
@@ -4,5 +4,9 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Keycloak": {
+    "Realm": "granit",
+    "AuthServerUrl": "http://localhost:8080"
   }
 }

--- a/src/GranitMicroservice.NotificationService/GranitMicroservice.NotificationService.csproj
+++ b/src/GranitMicroservice.NotificationService/GranitMicroservice.NotificationService.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <ItemGroup>
+    <ProjectReference Include="..\GranitMicroservice.ServiceDefaults\GranitMicroservice.ServiceDefaults.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/GranitMicroservice.NotificationService/GranitMicroservice.NotificationService.csproj
+++ b/src/GranitMicroservice.NotificationService/GranitMicroservice.NotificationService.csproj
@@ -1,7 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <ItemGroup>
-    <ProjectReference Include="..\GranitMicroservice.ServiceDefaults\GranitMicroservice.ServiceDefaults.csproj" />
+    <PackageReference Include="Granit.Notifications" />
+    <PackageReference Include="Granit.Persistence" />
+    <PackageReference Include="Granit.Persistence.Migrations" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GranitMicroservice.Shared.Hosting\GranitMicroservice.Shared.Hosting.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/GranitMicroservice.NotificationService/Handlers/CatalogProductCreatedHandler.cs
+++ b/src/GranitMicroservice.NotificationService/Handlers/CatalogProductCreatedHandler.cs
@@ -1,0 +1,27 @@
+using GranitMicroservice.Shared.Events;
+using Microsoft.Extensions.Logging;
+
+namespace GranitMicroservice.NotificationService.Handlers;
+
+/// <summary>
+/// Handles <see cref="CatalogProductCreatedEvent"/> from the CatalogService.
+/// Triggers a notification when a new product is added to the catalog.
+/// </summary>
+public sealed partial class CatalogProductCreatedHandler(
+    ILogger<CatalogProductCreatedHandler> logger)
+{
+    public async Task HandleAsync(
+        CatalogProductCreatedEvent @event,
+        CancellationToken cancellationToken)
+    {
+        LogProductCreatedNotification(@event.ProductId, @event.Name, @event.Price);
+
+        // TODO: Phase 3 — integrate with Granit.Notifications to send email/SignalR notifications
+        await Task.CompletedTask;
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Notification triggered for new product {ProductId}: {ProductName} at {Price:C}")]
+    private partial void LogProductCreatedNotification(Guid productId, string productName, decimal price);
+}

--- a/src/GranitMicroservice.NotificationService/Handlers/CatalogProductUpdatedHandler.cs
+++ b/src/GranitMicroservice.NotificationService/Handlers/CatalogProductUpdatedHandler.cs
@@ -1,0 +1,27 @@
+using GranitMicroservice.Shared.Events;
+using Microsoft.Extensions.Logging;
+
+namespace GranitMicroservice.NotificationService.Handlers;
+
+/// <summary>
+/// Handles <see cref="CatalogProductUpdatedEvent"/> from the CatalogService.
+/// Triggers a notification when a product is updated in the catalog.
+/// </summary>
+public sealed partial class CatalogProductUpdatedHandler(
+    ILogger<CatalogProductUpdatedHandler> logger)
+{
+    public async Task HandleAsync(
+        CatalogProductUpdatedEvent @event,
+        CancellationToken cancellationToken)
+    {
+        LogProductUpdatedNotification(@event.ProductId, @event.Name);
+
+        // TODO: Phase 3 — integrate with Granit.Notifications to send notifications
+        await Task.CompletedTask;
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Notification triggered for updated product {ProductId}: {ProductName}")]
+    private partial void LogProductUpdatedNotification(Guid productId, string productName);
+}

--- a/src/GranitMicroservice.NotificationService/NotificationServiceModule.cs
+++ b/src/GranitMicroservice.NotificationService/NotificationServiceModule.cs
@@ -1,0 +1,12 @@
+using Granit.Core.Modularity;
+using Granit.Notifications;
+using Granit.Persistence;
+using Granit.Persistence.Migrations;
+
+namespace GranitMicroservice.NotificationService;
+
+[DependsOn(
+    typeof(GranitNotificationsModule),
+    typeof(GranitPersistenceModule),
+    typeof(GranitPersistenceMigrationsModule))]
+public sealed class NotificationServiceModule : GranitModule;

--- a/src/GranitMicroservice.NotificationService/Persistence/NotificationServiceDbContext.cs
+++ b/src/GranitMicroservice.NotificationService/Persistence/NotificationServiceDbContext.cs
@@ -1,0 +1,19 @@
+using Granit.Core.DataFiltering;
+using Granit.Core.MultiTenancy;
+using Granit.Persistence.Extensions;
+using Microsoft.EntityFrameworkCore;
+
+namespace GranitMicroservice.NotificationService.Persistence;
+
+public sealed class NotificationServiceDbContext(
+    DbContextOptions<NotificationServiceDbContext> options,
+    ICurrentTenant? currentTenant = null,
+    IDataFilter? dataFilter = null) : DbContext(options)
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(NotificationServiceDbContext).Assembly);
+        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
+    }
+}

--- a/src/GranitMicroservice.NotificationService/Program.cs
+++ b/src/GranitMicroservice.NotificationService/Program.cs
@@ -1,0 +1,12 @@
+using GranitMicroservice.ServiceDefaults;
+
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+builder.AddServiceDefaults();
+
+WebApplication app = builder.Build();
+
+app.MapDefaultEndpoints();
+app.MapGet("/", () => new { Service = "NotificationService" });
+
+await app.RunAsync();

--- a/src/GranitMicroservice.NotificationService/Program.cs
+++ b/src/GranitMicroservice.NotificationService/Program.cs
@@ -1,12 +1,29 @@
+using Granit.Core.Extensions;
+using Granit.Persistence.Interceptors;
+using GranitMicroservice.NotificationService;
+using GranitMicroservice.NotificationService.Persistence;
 using GranitMicroservice.ServiceDefaults;
+using GranitMicroservice.Shared.Hosting.Extensions;
+using Microsoft.EntityFrameworkCore;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
-builder.AddServiceDefaults();
+await builder.AddSharedHostingAsync();
+
+await builder.AddGranitAsync(granit => granit
+    .AddModule<NotificationServiceModule>());
+
+builder.Services.AddDbContextFactory<NotificationServiceDbContext>((sp, options) =>
+{
+    options.UseNpgsql(builder.Configuration.GetConnectionString("notification-db"));
+    options.AddInterceptors(
+        sp.GetRequiredService<AuditedEntityInterceptor>());
+});
 
 WebApplication app = builder.Build();
 
+await app.UseGranitAsync();
+
 app.MapDefaultEndpoints();
-app.MapGet("/", () => new { Service = "NotificationService" });
 
 await app.RunAsync();

--- a/src/GranitMicroservice.NotificationService/Properties/launchSettings.json
+++ b/src/GranitMicroservice.NotificationService/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "applicationUrl": "http://localhost:5130",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/GranitMicroservice.NotificationService/appsettings.Development.json
+++ b/src/GranitMicroservice.NotificationService/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/GranitMicroservice.NotificationService/appsettings.json
+++ b/src/GranitMicroservice.NotificationService/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/GranitMicroservice.ServiceDefaults/Extensions.cs
+++ b/src/GranitMicroservice.ServiceDefaults/Extensions.cs
@@ -1,0 +1,103 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace GranitMicroservice.ServiceDefaults;
+
+/// <summary>
+/// Shared service defaults bridging .NET Aspire conventions with Granit modules.
+/// </summary>
+public static class Extensions
+{
+    /// <summary>
+    /// Configures OpenTelemetry, health checks, resilient HTTP clients, and service discovery.
+    /// </summary>
+    public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)
+    {
+        builder.ConfigureOpenTelemetry();
+        builder.AddDefaultHealthChecks();
+        builder.Services.AddServiceDiscovery();
+        builder.Services.ConfigureHttpClientDefaults(http =>
+        {
+            http.AddStandardResilienceHandler();
+            http.AddServiceDiscovery();
+        });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Maps health check endpoints: /health/live, /health/ready, /health/startup.
+    /// </summary>
+    public static WebApplication MapDefaultEndpoints(this WebApplication app)
+    {
+        app.MapHealthChecks("/health/live", new HealthCheckOptions
+        {
+            Predicate = registration => registration.Tags.Contains("live"),
+        });
+
+        app.MapHealthChecks("/health/ready", new HealthCheckOptions
+        {
+            Predicate = registration => registration.Tags.Contains("ready"),
+        });
+
+        app.MapHealthChecks("/health/startup", new HealthCheckOptions
+        {
+            Predicate = registration => registration.Tags.Contains("startup"),
+        });
+
+        return app;
+    }
+
+    private static IHostApplicationBuilder ConfigureOpenTelemetry(this IHostApplicationBuilder builder)
+    {
+        builder.Logging.AddOpenTelemetry(logging =>
+        {
+            logging.IncludeFormattedMessage = true;
+            logging.IncludeScopes = true;
+        });
+
+        builder.Services.AddOpenTelemetry()
+            .WithMetrics(metrics =>
+            {
+                metrics
+                    .AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation();
+            })
+            .WithTracing(tracing =>
+            {
+                tracing
+                    .AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation();
+            });
+
+        AddOpenTelemetryExporters(builder);
+
+        return builder;
+    }
+
+    private static void AddOpenTelemetryExporters(IHostApplicationBuilder builder)
+    {
+        var useOtlpExporter = !string.IsNullOrWhiteSpace(
+            builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+
+        if (useOtlpExporter)
+        {
+            builder.Services.AddOpenTelemetry().UseOtlpExporter();
+        }
+    }
+
+    private static IHostApplicationBuilder AddDefaultHealthChecks(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddHealthChecks()
+            .AddCheck("self", () => HealthCheckResult.Healthy(), ["live", "ready", "startup"]);
+
+        return builder;
+    }
+}

--- a/src/GranitMicroservice.ServiceDefaults/GranitMicroservice.ServiceDefaults.csproj
+++ b/src/GranitMicroservice.ServiceDefaults/GranitMicroservice.ServiceDefaults.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsAspireSharedProject>true</IsAspireSharedProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+  </ItemGroup>
+
+</Project>

--- a/src/GranitMicroservice.Shared.Hosting/Extensions/SharedHostingExtensions.cs
+++ b/src/GranitMicroservice.Shared.Hosting/Extensions/SharedHostingExtensions.cs
@@ -1,0 +1,26 @@
+using Granit.Bundle.Essentials;
+using Granit.Core.Extensions;
+using GranitMicroservice.ServiceDefaults;
+using Microsoft.AspNetCore.Builder;
+
+namespace GranitMicroservice.Shared.Hosting.Extensions;
+
+public static class SharedHostingExtensions
+{
+    /// <summary>
+    /// Configures cross-cutting concerns: Aspire ServiceDefaults, Granit Essentials,
+    /// Wolverine/PostgreSQL outbox, JWT Bearer auth, Redis caching, HTTP resilience.
+    /// </summary>
+    public static async Task<WebApplicationBuilder> AddSharedHostingAsync(
+        this WebApplicationBuilder builder,
+        Action<SharedHostingModule>? configureModule = null)
+    {
+        builder.AddServiceDefaults();
+
+        await builder.AddGranitAsync(granit => granit
+            .AddEssentials()
+            .AddModule<SharedHostingModule>());
+
+        return builder;
+    }
+}

--- a/src/GranitMicroservice.Shared.Hosting/GranitMicroservice.Shared.Hosting.csproj
+++ b/src/GranitMicroservice.Shared.Hosting/GranitMicroservice.Shared.Hosting.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Granit.Bundle.Essentials" />
+    <PackageReference Include="Granit.Wolverine.Postgresql" />
+    <PackageReference Include="Granit.EventBus.Wolverine" />
+    <PackageReference Include="Granit.Authentication.JwtBearer" />
+    <PackageReference Include="Granit.Caching.StackExchangeRedis" />
+    <PackageReference Include="Granit.Http.Resilience" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GranitMicroservice.ServiceDefaults\GranitMicroservice.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\GranitMicroservice.Shared\GranitMicroservice.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/GranitMicroservice.Shared.Hosting/SharedHostingModule.cs
+++ b/src/GranitMicroservice.Shared.Hosting/SharedHostingModule.cs
@@ -1,0 +1,20 @@
+using Granit.Authentication.JwtBearer;
+using Granit.Caching.StackExchangeRedis;
+using Granit.Core.Modularity;
+using Granit.EventBus.Wolverine;
+using Granit.Http.Resilience;
+using Granit.Wolverine.Postgresql;
+
+namespace GranitMicroservice.Shared.Hosting;
+
+/// <summary>
+/// Cross-cutting concerns shared by all microservices.
+/// Domain-specific modules (Identity, Notifications, Authorization) are forbidden here.
+/// </summary>
+[DependsOn(
+    typeof(GranitCachingRedisModule),
+    typeof(GranitEventBusWolverineModule),
+    typeof(GranitHttpResilienceModule),
+    typeof(GranitJwtBearerModule),
+    typeof(GranitWolverinePostgresqlModule))]
+public sealed class SharedHostingModule : GranitModule;

--- a/src/GranitMicroservice.Shared/Events/CatalogProductCreatedEvent.cs
+++ b/src/GranitMicroservice.Shared/Events/CatalogProductCreatedEvent.cs
@@ -1,0 +1,11 @@
+using Granit.Core.Events;
+
+namespace GranitMicroservice.Shared.Events;
+
+/// <summary>
+/// Published when a new product is created in the CatalogService.
+/// </summary>
+public sealed record CatalogProductCreatedEvent(
+    Guid ProductId,
+    string Name,
+    decimal Price) : IIntegrationEvent;

--- a/src/GranitMicroservice.Shared/Events/CatalogProductUpdatedEvent.cs
+++ b/src/GranitMicroservice.Shared/Events/CatalogProductUpdatedEvent.cs
@@ -1,0 +1,11 @@
+using Granit.Core.Events;
+
+namespace GranitMicroservice.Shared.Events;
+
+/// <summary>
+/// Published when an existing product is updated in the CatalogService.
+/// </summary>
+public sealed record CatalogProductUpdatedEvent(
+    Guid ProductId,
+    string Name,
+    decimal Price) : IIntegrationEvent;

--- a/src/GranitMicroservice.Shared/GranitMicroservice.Shared.csproj
+++ b/src/GranitMicroservice.Shared/GranitMicroservice.Shared.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="Granit.Core" />
+  </ItemGroup>
+
+</Project>

--- a/src/GranitMicroservice.Shared/README.md
+++ b/src/GranitMicroservice.Shared/README.md
@@ -1,0 +1,27 @@
+# GranitMicroservice.Shared — Integration Event Contracts
+
+This project contains **integration event contracts** shared across microservices.
+It depends only on `Granit.Core` and must never contain business logic, services,
+or infrastructure code.
+
+## Rules
+
+- All events are `sealed record` types implementing `IIntegrationEvent`
+- Events contain only flat, serializable properties (no EF entities, no domain objects)
+- Naming convention: `{Service}{Entity}{Action}Event` (e.g., `CatalogProductCreatedEvent`)
+
+## Scaling trajectory
+
+This shared C# project approach works well for:
+
+- Small teams (1-5 developers)
+- Monorepo setups
+- Early-stage microservice architectures
+
+For multi-team, large-scale setups, consider evolving to:
+
+1. **Independent NuGet packages** — version contracts independently per service
+2. **AsyncAPI / Protobuf** — generate DTOs from schema definitions to eliminate
+   compile-time coupling between producer and consumer
+3. **Schema registry** — centralized contract validation with backward compatibility
+   checks (e.g., Confluent Schema Registry pattern)

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))" />
+
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);CA2254</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -2,10 +2,11 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))" />
 
   <PropertyGroup>
-    <NoWarn>$(NoWarn);CA2254</NoWarn>
+    <NoWarn>$(NoWarn);CA2254;xUnit1051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <Using Include="Xunit" />
+    <Using Include="Microsoft.EntityFrameworkCore" />
   </ItemGroup>
 </Project>

--- a/tests/GranitMicroservice.CatalogService.Tests.Integration/CatalogDbFixture.cs
+++ b/tests/GranitMicroservice.CatalogService.Tests.Integration/CatalogDbFixture.cs
@@ -1,0 +1,31 @@
+using GranitMicroservice.CatalogService.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Testcontainers.PostgreSql;
+
+namespace GranitMicroservice.CatalogService.Tests.Integration;
+
+public sealed class CatalogDbFixture : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("postgres:17-alpine")
+        .Build();
+
+    public CatalogDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<CatalogDbContext>()
+            .UseNpgsql(_container.GetConnectionString())
+            .Options;
+
+        return new CatalogDbContext(options);
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await _container.StartAsync();
+
+        await using var db = CreateDbContext();
+        await db.Database.EnsureCreatedAsync();
+    }
+
+    public async ValueTask DisposeAsync() =>
+        await _container.DisposeAsync();
+}

--- a/tests/GranitMicroservice.CatalogService.Tests.Integration/GranitMicroservice.CatalogService.Tests.Integration.csproj
+++ b/tests/GranitMicroservice.CatalogService.Tests.Integration/GranitMicroservice.CatalogService.Tests.Integration.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="Testcontainers.PostgreSql" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\GranitMicroservice.CatalogService\GranitMicroservice.CatalogService.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/GranitMicroservice.CatalogService.Tests.Integration/MigrationSmokeTests.cs
+++ b/tests/GranitMicroservice.CatalogService.Tests.Integration/MigrationSmokeTests.cs
@@ -1,0 +1,36 @@
+using Shouldly;
+
+namespace GranitMicroservice.CatalogService.Tests.Integration;
+
+public sealed class MigrationSmokeTests(CatalogDbFixture fixture) : IClassFixture<CatalogDbFixture>
+{
+    [Fact]
+    public async Task Should_apply_schema_successfully()
+    {
+        await using var db = fixture.CreateDbContext();
+
+        var canConnect = await db.Database.CanConnectAsync();
+
+        canConnect.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Should_have_products_table()
+    {
+        await using var db = fixture.CreateDbContext();
+
+        var count = await db.Products.CountAsync();
+
+        count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Should_have_categories_table()
+    {
+        await using var db = fixture.CreateDbContext();
+
+        var count = await db.Categories.CountAsync();
+
+        count.ShouldBeGreaterThanOrEqualTo(0);
+    }
+}

--- a/tests/GranitMicroservice.CatalogService.Tests.Integration/ProductCrudTests.cs
+++ b/tests/GranitMicroservice.CatalogService.Tests.Integration/ProductCrudTests.cs
@@ -1,0 +1,91 @@
+using GranitMicroservice.CatalogService.Domain;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+
+namespace GranitMicroservice.CatalogService.Tests.Integration;
+
+public sealed class ProductCrudTests(CatalogDbFixture fixture) : IClassFixture<CatalogDbFixture>
+{
+    [Fact]
+    public async Task Should_create_and_retrieve_product()
+    {
+        await using var db = fixture.CreateDbContext();
+
+        var category = new Category { Name = "Electronics" };
+        db.Categories.Add(category);
+        await db.SaveChangesAsync();
+
+        var product = new Product
+        {
+            Name = "Laptop",
+            Description = "A fast laptop",
+            Price = 999.99m,
+            CategoryId = category.Id,
+        };
+
+        db.Products.Add(product);
+        await db.SaveChangesAsync();
+
+        var retrieved = await db.Products
+            .Include(p => p.Category)
+            .FirstAsync(p => p.Id == product.Id);
+
+        retrieved.Name.ShouldBe("Laptop");
+        retrieved.Price.ShouldBe(999.99m);
+        retrieved.Category.ShouldNotBeNull();
+        retrieved.Category!.Name.ShouldBe("Electronics");
+    }
+
+    [Fact]
+    public async Task Should_update_product()
+    {
+        await using var db = fixture.CreateDbContext();
+
+        var category = new Category { Name = "Books" };
+        db.Categories.Add(category);
+
+        var product = new Product
+        {
+            Name = "Old Title",
+            Price = 10m,
+            CategoryId = category.Id,
+        };
+
+        db.Products.Add(product);
+        await db.SaveChangesAsync();
+
+        product.Name = "New Title";
+        product.Price = 15m;
+        await db.SaveChangesAsync();
+
+        var retrieved = await db.Products.FirstAsync(p => p.Id == product.Id);
+
+        retrieved.Name.ShouldBe("New Title");
+        retrieved.Price.ShouldBe(15m);
+    }
+
+    [Fact]
+    public async Task Should_delete_product()
+    {
+        await using var db = fixture.CreateDbContext();
+
+        var category = new Category { Name = "Toys" };
+        db.Categories.Add(category);
+
+        var product = new Product
+        {
+            Name = "Teddy Bear",
+            Price = 25m,
+            CategoryId = category.Id,
+        };
+
+        db.Products.Add(product);
+        await db.SaveChangesAsync();
+
+        db.Products.Remove(product);
+        await db.SaveChangesAsync();
+
+        var exists = await db.Products.AnyAsync(p => p.Id == product.Id);
+        exists.ShouldBeFalse();
+    }
+}

--- a/tests/GranitMicroservice.CatalogService.Tests/Domain/ProductTests.cs
+++ b/tests/GranitMicroservice.CatalogService.Tests/Domain/ProductTests.cs
@@ -1,0 +1,39 @@
+using GranitMicroservice.CatalogService.Domain;
+using Shouldly;
+
+namespace GranitMicroservice.CatalogService.Tests.Domain;
+
+public sealed class ProductTests
+{
+    [Fact]
+    public void Should_create_product_with_required_properties()
+    {
+        var categoryId = Guid.NewGuid();
+
+        var product = new Product
+        {
+            Name = "Test Product",
+            Description = "A test product",
+            Price = 19.99m,
+            CategoryId = categoryId,
+        };
+
+        product.Name.ShouldBe("Test Product");
+        product.Description.ShouldBe("A test product");
+        product.Price.ShouldBe(19.99m);
+        product.CategoryId.ShouldBe(categoryId);
+    }
+
+    [Fact]
+    public void Should_allow_null_description()
+    {
+        var product = new Product
+        {
+            Name = "Minimal Product",
+            Price = 0m,
+            CategoryId = Guid.NewGuid(),
+        };
+
+        product.Description.ShouldBeNull();
+    }
+}

--- a/tests/GranitMicroservice.CatalogService.Tests/Endpoints/CatalogProductResponseTests.cs
+++ b/tests/GranitMicroservice.CatalogService.Tests/Endpoints/CatalogProductResponseTests.cs
@@ -1,0 +1,40 @@
+using GranitMicroservice.CatalogService.Endpoints;
+using Shouldly;
+
+namespace GranitMicroservice.CatalogService.Tests.Endpoints;
+
+public sealed class CatalogProductResponseTests
+{
+    [Fact]
+    public void Should_create_response_with_all_properties()
+    {
+        var id = Guid.NewGuid();
+        var categoryId = Guid.NewGuid();
+        var createdAt = DateTimeOffset.UtcNow;
+
+        var response = new CatalogProductResponse(
+            id, "Widget", "A widget", 9.99m, categoryId, "Gadgets", createdAt, null);
+
+        response.Id.ShouldBe(id);
+        response.Name.ShouldBe("Widget");
+        response.Description.ShouldBe("A widget");
+        response.Price.ShouldBe(9.99m);
+        response.CategoryId.ShouldBe(categoryId);
+        response.CategoryName.ShouldBe("Gadgets");
+        response.CreatedAt.ShouldBe(createdAt);
+        response.ModifiedAt.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Should_support_record_equality()
+    {
+        var id = Guid.NewGuid();
+        var categoryId = Guid.NewGuid();
+        var createdAt = DateTimeOffset.UtcNow;
+
+        var a = new CatalogProductResponse(id, "Widget", null, 9.99m, categoryId, null, createdAt, null);
+        var b = new CatalogProductResponse(id, "Widget", null, 9.99m, categoryId, null, createdAt, null);
+
+        a.ShouldBe(b);
+    }
+}

--- a/tests/GranitMicroservice.CatalogService.Tests/GranitMicroservice.CatalogService.Tests.csproj
+++ b/tests/GranitMicroservice.CatalogService.Tests/GranitMicroservice.CatalogService.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="Bogus" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\GranitMicroservice.CatalogService\GranitMicroservice.CatalogService.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/GranitMicroservice.CatalogService.Tests/Validators/CreateCatalogProductValidatorTests.cs
+++ b/tests/GranitMicroservice.CatalogService.Tests/Validators/CreateCatalogProductValidatorTests.cs
@@ -1,0 +1,78 @@
+using Bogus;
+using FluentValidation.TestHelper;
+using GranitMicroservice.CatalogService.Endpoints;
+using GranitMicroservice.CatalogService.Validators;
+
+namespace GranitMicroservice.CatalogService.Tests.Validators;
+
+public sealed class CreateCatalogProductValidatorTests
+{
+    private readonly CreateCatalogProductValidator _validator = new();
+
+    private readonly Faker<CreateCatalogProductRequest> _validRequestFaker = new Faker<CreateCatalogProductRequest>()
+        .CustomInstantiator(f => new CreateCatalogProductRequest(
+            f.Commerce.ProductName(),
+            f.Commerce.ProductDescription(),
+            decimal.Parse(f.Commerce.Price()),
+            f.Random.Guid()));
+
+    [Fact]
+    public void Should_pass_for_valid_request()
+    {
+        var request = _validRequestFaker.Generate();
+
+        var result = _validator.TestValidate(request);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Should_fail_when_name_is_empty()
+    {
+        var request = _validRequestFaker.Generate() with { Name = "" };
+
+        var result = _validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.Name);
+    }
+
+    [Fact]
+    public void Should_fail_when_name_exceeds_max_length()
+    {
+        var request = _validRequestFaker.Generate() with { Name = new string('A', 257) };
+
+        var result = _validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.Name);
+    }
+
+    [Fact]
+    public void Should_fail_when_price_is_negative()
+    {
+        var request = _validRequestFaker.Generate() with { Price = -1m };
+
+        var result = _validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.Price);
+    }
+
+    [Fact]
+    public void Should_pass_when_price_is_zero()
+    {
+        var request = _validRequestFaker.Generate() with { Price = 0m };
+
+        var result = _validator.TestValidate(request);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Price);
+    }
+
+    [Fact]
+    public void Should_fail_when_category_id_is_empty()
+    {
+        var request = _validRequestFaker.Generate() with { CategoryId = Guid.Empty };
+
+        var result = _validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.CategoryId);
+    }
+}

--- a/tests/GranitMicroservice.CatalogService.Tests/Validators/UpdateCatalogProductValidatorTests.cs
+++ b/tests/GranitMicroservice.CatalogService.Tests/Validators/UpdateCatalogProductValidatorTests.cs
@@ -1,0 +1,58 @@
+using Bogus;
+using FluentValidation.TestHelper;
+using GranitMicroservice.CatalogService.Endpoints;
+using GranitMicroservice.CatalogService.Validators;
+
+namespace GranitMicroservice.CatalogService.Tests.Validators;
+
+public sealed class UpdateCatalogProductValidatorTests
+{
+    private readonly UpdateCatalogProductValidator _validator = new();
+
+    private readonly Faker<UpdateCatalogProductRequest> _validRequestFaker = new Faker<UpdateCatalogProductRequest>()
+        .CustomInstantiator(f => new UpdateCatalogProductRequest(
+            f.Commerce.ProductName(),
+            f.Commerce.ProductDescription(),
+            decimal.Parse(f.Commerce.Price()),
+            f.Random.Guid()));
+
+    [Fact]
+    public void Should_pass_for_valid_request()
+    {
+        var request = _validRequestFaker.Generate();
+
+        var result = _validator.TestValidate(request);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Should_fail_when_name_is_empty()
+    {
+        var request = _validRequestFaker.Generate() with { Name = "" };
+
+        var result = _validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.Name);
+    }
+
+    [Fact]
+    public void Should_fail_when_price_is_negative()
+    {
+        var request = _validRequestFaker.Generate() with { Price = -0.01m };
+
+        var result = _validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.Price);
+    }
+
+    [Fact]
+    public void Should_fail_when_category_id_is_empty()
+    {
+        var request = _validRequestFaker.Generate() with { CategoryId = Guid.Empty };
+
+        var result = _validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.CategoryId);
+    }
+}

--- a/tests/GranitMicroservice.IdentityService.Tests/GranitMicroservice.IdentityService.Tests.csproj
+++ b/tests/GranitMicroservice.IdentityService.Tests/GranitMicroservice.IdentityService.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\GranitMicroservice.IdentityService\GranitMicroservice.IdentityService.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/GranitMicroservice.IdentityService.Tests/IdentityServiceModuleTests.cs
+++ b/tests/GranitMicroservice.IdentityService.Tests/IdentityServiceModuleTests.cs
@@ -1,0 +1,24 @@
+using Granit.Core.Modularity;
+using Shouldly;
+
+namespace GranitMicroservice.IdentityService.Tests;
+
+public sealed class IdentityServiceModuleTests
+{
+    [Fact]
+    public void Module_should_inherit_from_GranitModule()
+    {
+        var module = new IdentityServiceModule();
+
+        module.ShouldBeAssignableTo<GranitModule>();
+    }
+
+    [Fact]
+    public void Module_should_declare_dependencies_via_DependsOn()
+    {
+        var attributes = typeof(IdentityServiceModule)
+            .GetCustomAttributes(typeof(DependsOnAttribute), inherit: false);
+
+        attributes.ShouldNotBeEmpty();
+    }
+}

--- a/tests/GranitMicroservice.NotificationService.Tests/GranitMicroservice.NotificationService.Tests.csproj
+++ b/tests/GranitMicroservice.NotificationService.Tests/GranitMicroservice.NotificationService.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="Bogus" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\GranitMicroservice.NotificationService\GranitMicroservice.NotificationService.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/GranitMicroservice.NotificationService.Tests/Handlers/CatalogProductCreatedHandlerTests.cs
+++ b/tests/GranitMicroservice.NotificationService.Tests/Handlers/CatalogProductCreatedHandlerTests.cs
@@ -1,0 +1,40 @@
+using GranitMicroservice.NotificationService.Handlers;
+using GranitMicroservice.Shared.Events;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shouldly;
+
+namespace GranitMicroservice.NotificationService.Tests.Handlers;
+
+public sealed class CatalogProductCreatedHandlerTests
+{
+    private readonly ILogger<CatalogProductCreatedHandler> _logger =
+        Substitute.For<ILogger<CatalogProductCreatedHandler>>();
+
+    private readonly CatalogProductCreatedHandler _handler;
+
+    public CatalogProductCreatedHandlerTests() =>
+        _handler = new CatalogProductCreatedHandler(_logger);
+
+    [Fact]
+    public async Task Should_handle_product_created_event_without_throwing()
+    {
+        var @event = new CatalogProductCreatedEvent(
+            Guid.NewGuid(), "Test Product", 29.99m);
+
+        var act = () => _handler.HandleAsync(@event, CancellationToken.None);
+
+        await Should.NotThrowAsync(act);
+    }
+
+    [Fact]
+    public async Task Should_handle_zero_price_product()
+    {
+        var @event = new CatalogProductCreatedEvent(
+            Guid.NewGuid(), "Free Product", 0m);
+
+        var act = () => _handler.HandleAsync(@event, CancellationToken.None);
+
+        await Should.NotThrowAsync(act);
+    }
+}

--- a/tests/GranitMicroservice.NotificationService.Tests/Handlers/CatalogProductUpdatedHandlerTests.cs
+++ b/tests/GranitMicroservice.NotificationService.Tests/Handlers/CatalogProductUpdatedHandlerTests.cs
@@ -1,0 +1,29 @@
+using GranitMicroservice.NotificationService.Handlers;
+using GranitMicroservice.Shared.Events;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shouldly;
+
+namespace GranitMicroservice.NotificationService.Tests.Handlers;
+
+public sealed class CatalogProductUpdatedHandlerTests
+{
+    private readonly ILogger<CatalogProductUpdatedHandler> _logger =
+        Substitute.For<ILogger<CatalogProductUpdatedHandler>>();
+
+    private readonly CatalogProductUpdatedHandler _handler;
+
+    public CatalogProductUpdatedHandlerTests() =>
+        _handler = new CatalogProductUpdatedHandler(_logger);
+
+    [Fact]
+    public async Task Should_handle_product_updated_event()
+    {
+        var @event = new CatalogProductUpdatedEvent(
+            Guid.NewGuid(), "Updated Product", 49.99m);
+
+        var act = () => _handler.HandleAsync(@event, CancellationToken.None);
+
+        await Should.NotThrowAsync(act);
+    }
+}


### PR DESCRIPTION
## Summary

- **Phase 1 — Foundation**: Solution structure (`Directory.Build.props`, `Directory.Packages.props`, `global.json`, `.slnx`), Aspire AppHost (PostgreSQL ×3, Redis, RabbitMQ, Keycloak), ServiceDefaults (OpenTelemetry, health checks, resilience), `dotnet new granit-microservice` template config
- **Phase 2 — Services**: Shared integration event contracts, Shared.Hosting cross-cutting concerns (`AddSharedHostingAsync()`), CatalogService (domain + CRUD endpoints + event publishing), IdentityService (Keycloak + Granit.Identity), NotificationService (event-driven Wolverine handlers), ApiGateway (YARP + JWT + rate limiting + Scalar UI)
- **Build**: 8/8 projects, 0 warnings, 0 errors — Granit packages consumed via GitHub Packages (`0.1.0-*`)

## Stories covered

Closes #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20

## Test plan

- [ ] `dotnet restore GranitMicroservice.slnx` succeeds (requires `granit-registry` credentials)
- [ ] `dotnet build GranitMicroservice.slnx` — 0 errors, 0 warnings
- [ ] `dotnet new install .` then `dotnet new granit-microservice -n Acme.Platform -o /tmp/acme` — all files renamed
- [ ] `dotnet build /tmp/acme/Acme.Platform.slnx` compiles after scaffold
- [ ] `dotnet run --project src/GranitMicroservice.AppHost` — Aspire dashboard shows all resources
- [ ] Keycloak realm imported with 2 clients, 2 roles, 2 test users

🤖 Generated with [Claude Code](https://claude.com/claude-code)
