### PR TITLE
fix(persistence+nuget): sync template with latest Granit changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,9 @@
 # Pipeline: build+test → security → sbom
 #
 # Required secrets:
-#   GRANIT_PACKAGES_TOKEN — GitHub Packages token for the Granit.* NuGet feed
+#   GITLAB_NUGET_USER  — GitLab username (deploy token user) for the
+#                        Granit.* NuGet feed on gitlab.digitaldynamics.be
+#   GITLAB_NUGET_TOKEN — GitLab deploy token (read_package_registry scope)
 # =============================================================================
 
 name: CI
@@ -35,7 +37,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
+    # Credentials for the GitLab Package Registry passed via
+    # NuGetPackageSourceCredentials_<sourceName> rather than written to
+    # nuget.config on disk. The suffix MUST match the source key in
+    # nuget.config (`GranitGitLab`).
+    env:
+      NuGetPackageSourceCredentials_GranitGitLab: Username=${{ secrets.GITLAB_NUGET_USER }};Password=${{ secrets.GITLAB_NUGET_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -43,16 +50,6 @@ jobs:
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
           global-json-file: global.json
-
-      - name: Authenticate to GitHub Packages
-        env:
-          GRANIT_PACKAGES_TOKEN: ${{ secrets.GRANIT_PACKAGES_TOKEN }}
-        run: |
-          dotnet nuget update source granit-registry \
-            --username granit-fx \
-            --password "$GRANIT_PACKAGES_TOKEN" \
-            --store-password-in-clear-text \
-            --configfile nuget.config
 
       - name: Restore
         run: dotnet restore GranitMicroservice.slnx
@@ -99,7 +96,8 @@ jobs:
     continue-on-error: true
     permissions:
       contents: read
-      packages: read
+    env:
+      NuGetPackageSourceCredentials_GranitGitLab: Username=${{ secrets.GITLAB_NUGET_USER }};Password=${{ secrets.GITLAB_NUGET_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -107,16 +105,6 @@ jobs:
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
           global-json-file: global.json
-
-      - name: Authenticate to GitHub Packages
-        env:
-          GRANIT_PACKAGES_TOKEN: ${{ secrets.GRANIT_PACKAGES_TOKEN }}
-        run: |
-          dotnet nuget update source granit-registry \
-            --username granit-fx \
-            --password "$GRANIT_PACKAGES_TOKEN" \
-            --store-password-in-clear-text \
-            --configfile nuget.config
 
       - name: Check vulnerable packages
         run: |
@@ -141,7 +129,8 @@ jobs:
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read
-      packages: read
+    env:
+      NuGetPackageSourceCredentials_GranitGitLab: Username=${{ secrets.GITLAB_NUGET_USER }};Password=${{ secrets.GITLAB_NUGET_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -149,16 +138,6 @@ jobs:
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
           global-json-file: global.json
-
-      - name: Authenticate to GitHub Packages
-        env:
-          GRANIT_PACKAGES_TOKEN: ${{ secrets.GRANIT_PACKAGES_TOKEN }}
-        run: |
-          dotnet nuget update source granit-registry \
-            --username granit-fx \
-            --password "$GRANIT_PACKAGES_TOKEN" \
-            --store-password-in-clear-text \
-            --configfile nuget.config
 
       - name: Install CycloneDX
         run: dotnet tool install --global CycloneDX

--- a/.github/workflows/template-validation.yml
+++ b/.github/workflows/template-validation.yml
@@ -17,8 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
       issues: write  # required for "Create issue on failure" step
+    # GitLab Package Registry credentials for the Granit.* NuGet feed.
+    # Source key in the scaffolded nuget.config is `GranitGitLab`.
+    env:
+      NuGetPackageSourceCredentials_GranitGitLab: Username=${{ secrets.GITLAB_NUGET_USER }};Password=${{ secrets.GITLAB_NUGET_TOKEN }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -33,16 +36,6 @@ jobs:
 
       - name: Scaffold solution
         run: dotnet new granit-microservice -n TestScaffold -o /tmp/test-scaffold
-
-      - name: Authenticate to GitHub Packages
-        env:
-          GRANIT_PACKAGES_TOKEN: ${{ secrets.GRANIT_PACKAGES_TOKEN }}
-        run: |
-          dotnet nuget update source granit-registry \
-            --username granit-fx \
-            --password "$GRANIT_PACKAGES_TOKEN" \
-            --store-password-in-clear-text \
-            --configfile /tmp/test-scaffold/nuget.config
 
       - name: Build scaffolded solution
         run: dotnet build /tmp/test-scaffold/TestScaffold.slnx

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # CLAUDE.md - Granit Microservice Template
 
+> Global conventions (git workflow, security, personas, DoD, refactoring, third-party
+> licenses, markdown) live in `~/.claude/CLAUDE.md`. Code quality and anti-patterns
+> follow `granit-dotnet/CLAUDE.md`. Neither is repeated here.
+
 ## Project
 
 - **Type**: .NET Aspire solution template for Granit microservices
@@ -37,13 +41,8 @@ infra/keycloak-realms/                 # Keycloak realm JSON for Aspire import
 ## Commands
 
 ```bash
-# Build entire solution
 dotnet build GranitMicroservice.slnx
-
-# Run tests
 dotnet test GranitMicroservice.slnx
-
-# Start all services via Aspire
 dotnet run --project src/GranitMicroservice.AppHost
 
 # Scaffold from template
@@ -86,21 +85,3 @@ Each microservice owns its PostgreSQL database. No shared databases.
 ### No Docker Compose
 
 Aspire orchestrates everything. No `docker-compose.yml`.
-
-## Code quality
-
-Follows `granit-dotnet` conventions (see its CLAUDE.md):
-
-- C# 14: primary constructors, collection expressions, `field` keyword, extension members
-- `[LoggerMessage]` for logging, `TimeProvider` for time, `[GeneratedRegex]` for regex
-- `TypedResults` for API responses, `*Request`/`*Response` DTOs (never `*Dto`)
-- File-scoped namespaces, `var` when type is apparent
-
-## Anti-patterns
-
-- No `DateTime.Now`/`UtcNow` — inject `TimeProvider`
-- No `new Regex(...)` — use `[GeneratedRegex]`
-- No Swashbuckle/NSwag — use `Microsoft.AspNetCore.OpenApi` + Scalar
-- No `docker-compose` — Aspire only
-- No shared DbContext across services
-- No business packages in Shared.Hosting

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Full documentation at [granit-fx.dev](https://granit-fx.dev).
 
 - [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
 - [Docker](https://www.docker.com/products/docker-desktop/) (for Aspire containers)
-- Access to [Granit GitHub Packages](https://github.com/orgs/granit-fx/packages)
+- Access to the Granit GitLab Package Registry (`gitlab.digitaldynamics.be`)
+  — see [docs/getting-started.md](docs/getting-started.md) for credential setup
 
 ## Quick start
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,20 +4,20 @@
 
 1. **.NET 10 SDK** — [download](https://dotnet.microsoft.com/download/dotnet/10.0)
 2. **Docker Desktop** — required for Aspire containers
-3. **GitHub Packages access** — configure NuGet credentials for `granit-fx`
+3. **GitLab Package Registry access** — credentials for the Granit.* NuGet feed
+   on `gitlab.digitaldynamics.be`
 
 ### Configure NuGet credentials
 
+The `nuget.config` already declares the `GranitGitLab` package source. Provide
+credentials via the environment variable below (matches the source key,
+avoids writing the token to disk):
+
 ```bash
-dotnet nuget add source \
-  https://nuget.pkg.github.com/granit-fx/index.json \
-  --name granit-registry \
-  --username YOUR_GITHUB_USERNAME \
-  --password YOUR_GITHUB_PAT \
-  --store-password-in-clear-text
+export NuGetPackageSourceCredentials_GranitGitLab="Username=$GITLAB_USER;Password=$GITLAB_DEPLOY_TOKEN"
 ```
 
-Your PAT needs `read:packages` scope.
+The deploy token needs the `read_package_registry` scope.
 
 ## Scaffold a new solution
 

--- a/nuget.config
+++ b/nuget.config
@@ -3,13 +3,19 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="granit-registry" value="https://nuget.pkg.github.com/granit-fx/index.json" />
+    <!-- Granit framework packages: GitLab Package Registry (project-level URL,
+         works without GitLab Premium). Source name kept dash-free so the
+         NuGetPackageSourceCredentials_<name> env var doesn't get mangled by
+         XmlConvert encoding (_x002D_). GitHub Packages was used previously
+         and is kept commented for rapid rollback. -->
+    <!-- <add key="GranitGitHub" value="https://nuget.pkg.github.com/granit-fx/index.json" /> -->
+    <add key="GranitGitLab" value="https://gitlab.digitaldynamics.be/api/v4/projects/11/packages/nuget/index.json" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="nuget.org">
       <package pattern="*" />
     </packageSource>
-    <packageSource key="granit-registry">
+    <packageSource key="GranitGitLab">
       <package pattern="Granit" />
       <package pattern="Granit.*" />
     </packageSource>

--- a/src/GranitMicroservice.ApiGateway/Program.cs
+++ b/src/GranitMicroservice.ApiGateway/Program.cs
@@ -66,7 +66,7 @@ app.MapDefaultEndpoints();
 
 app.UseCors();
 app.UseGranitBffYarp();
-app.MapGranitBffEndpoints();
+app.MapGranitBff();
 
 // ── Step 6 · OpenAPI spec passthrough ─────────────────────────────────────────
 app.MapGet("/openapi/catalog.json", async (IHttpClientFactory factory) =>

--- a/src/GranitMicroservice.CatalogService/Persistence/CatalogDbContext.cs
+++ b/src/GranitMicroservice.CatalogService/Persistence/CatalogDbContext.cs
@@ -1,6 +1,6 @@
 using Granit.DataFiltering;
 using Granit.MultiTenancy;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore;
 using GranitMicroservice.CatalogService.Domain;
 using Microsoft.EntityFrameworkCore;
 
@@ -8,17 +8,15 @@ namespace GranitMicroservice.CatalogService.Persistence;
 
 public sealed class CatalogDbContext(
     DbContextOptions<CatalogDbContext> options,
-    ICurrentTenant? currentTenant = null,
-    IDataFilter? dataFilter = null) : DbContext(options)
+    ICurrentTenant currentTenant,
+    IDataFilter? dataFilter = null) : GranitDbContext(options, currentTenant, dataFilter)
 {
     public DbSet<Product> Products => Set<Product>();
 
     public DbSet<Category> Categories => Set<Category>();
 
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
     {
-        base.OnModelCreating(modelBuilder);
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(CatalogDbContext).Assembly);
-        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
     }
 }

--- a/src/GranitMicroservice.CatalogService/Persistence/CatalogDbContextFactory.cs
+++ b/src/GranitMicroservice.CatalogService/Persistence/CatalogDbContextFactory.cs
@@ -1,3 +1,4 @@
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.Extensions.Configuration;
@@ -26,6 +27,6 @@ internal sealed class CatalogDbContextFactory : IDesignTimeDbContextFactory<Cata
 
         DbContextOptionsBuilder<CatalogDbContext> builder = new();
         builder.UseNpgsql(connectionString);
-        return new CatalogDbContext(builder.Options);
+        return new CatalogDbContext(builder.Options, GranitDesignTime.CurrentTenant, GranitDesignTime.DataFilter);
     }
 }

--- a/src/GranitMicroservice.IdentityService/Persistence/IdentityServiceDbContext.cs
+++ b/src/GranitMicroservice.IdentityService/Persistence/IdentityServiceDbContext.cs
@@ -1,24 +1,23 @@
 using Granit.DataFiltering;
-using Granit.MultiTenancy;
+using Granit.Identity.Federated.Domain;
 using Granit.Identity.Federated.EntityFrameworkCore.DbContext;
-using Granit.Identity.Federated.EntityFrameworkCore.Entities;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace GranitMicroservice.IdentityService.Persistence;
 
 public sealed class IdentityServiceDbContext(
     DbContextOptions<IdentityServiceDbContext> options,
-    ICurrentTenant? currentTenant = null,
-    IDataFilter? dataFilter = null) : DbContext(options), IUserCacheDbContext
+    ICurrentTenant currentTenant,
+    IDataFilter? dataFilter = null)
+    : GranitDbContext(options, currentTenant, dataFilter), IUserCacheDbContext
 {
-    public DbSet<UserCacheEntry> UserCacheEntries => Set<UserCacheEntry>();
+    public DbSet<FederatedIdentity> FederatedIdentities => Set<FederatedIdentity>();
 
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
     {
-        base.OnModelCreating(modelBuilder);
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(IdentityServiceDbContext).Assembly);
         modelBuilder.ConfigureIdentityModule();
-        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
     }
 }

--- a/src/GranitMicroservice.IdentityService/Persistence/IdentityServiceDbContextFactory.cs
+++ b/src/GranitMicroservice.IdentityService/Persistence/IdentityServiceDbContextFactory.cs
@@ -1,3 +1,4 @@
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.Extensions.Configuration;
@@ -26,6 +27,6 @@ internal sealed class IdentityServiceDbContextFactory : IDesignTimeDbContextFact
 
         DbContextOptionsBuilder<IdentityServiceDbContext> builder = new();
         builder.UseNpgsql(connectionString);
-        return new IdentityServiceDbContext(builder.Options);
+        return new IdentityServiceDbContext(builder.Options, GranitDesignTime.CurrentTenant, GranitDesignTime.DataFilter);
     }
 }

--- a/src/GranitMicroservice.IdentityService/Program.cs
+++ b/src/GranitMicroservice.IdentityService/Program.cs
@@ -84,13 +84,13 @@ app.UseGranitSecurityHeaders();
 // MapGranitHealthChecks → /health/live (always 200), /health/ready (readiness
 //   tag), /health/startup (startup tag) with structured JSON and stampede cache.
 // MapOpenApi            → /openapi/v1.json
-// MapIdentityUserCacheEndpoints → REST endpoints for the local user cache
+// MapGranitIdentityUserCache → REST endpoints for the local user cache
 //   (GET /users, GET /users/{id}, …)
 //   Granit modules register services but do NOT auto-map routes — always explicit.
 // MapScalarApiReference → interactive API explorer at /scalar
 app.MapGranitHealthChecks();
 app.MapOpenApi();
-app.MapIdentityUserCacheEndpoints();
+app.MapGranitIdentityUserCache();
 app.MapScalarApiReference();
 
 await app.RunAsync();

--- a/src/GranitMicroservice.NotificationService/Persistence/NotificationServiceDbContext.cs
+++ b/src/GranitMicroservice.NotificationService/Persistence/NotificationServiceDbContext.cs
@@ -1,20 +1,18 @@
 using Granit.DataFiltering;
 using Granit.MultiTenancy;
 using Granit.Notifications.EntityFrameworkCore.Extensions;
-using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace GranitMicroservice.NotificationService.Persistence;
 
 public sealed class NotificationServiceDbContext(
     DbContextOptions<NotificationServiceDbContext> options,
-    ICurrentTenant? currentTenant = null,
-    IDataFilter? dataFilter = null) : DbContext(options)
+    ICurrentTenant currentTenant,
+    IDataFilter? dataFilter = null) : GranitDbContext(options, currentTenant, dataFilter)
 {
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
     {
-        base.OnModelCreating(modelBuilder);
         modelBuilder.ConfigureNotificationsModule();
-        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
     }
 }

--- a/src/GranitMicroservice.NotificationService/Persistence/NotificationServiceDbContextFactory.cs
+++ b/src/GranitMicroservice.NotificationService/Persistence/NotificationServiceDbContextFactory.cs
@@ -1,3 +1,4 @@
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.Extensions.Configuration;
@@ -26,6 +27,6 @@ internal sealed class NotificationServiceDbContextFactory : IDesignTimeDbContext
 
         DbContextOptionsBuilder<NotificationServiceDbContext> builder = new();
         builder.UseNpgsql(connectionString);
-        return new NotificationServiceDbContext(builder.Options);
+        return new NotificationServiceDbContext(builder.Options, GranitDesignTime.CurrentTenant, GranitDesignTime.DataFilter);
     }
 }

--- a/tests/GranitMicroservice.CatalogService.Tests.Integration/CatalogDbFixture.cs
+++ b/tests/GranitMicroservice.CatalogService.Tests.Integration/CatalogDbFixture.cs
@@ -1,3 +1,4 @@
+using Granit.Persistence.EntityFrameworkCore;
 using GranitMicroservice.CatalogService.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Testcontainers.PostgreSql;
@@ -15,7 +16,7 @@ public sealed class CatalogDbFixture : IAsyncLifetime
             .UseNpgsql(_container.GetConnectionString())
             .Options;
 
-        return new CatalogDbContext(options);
+        return new CatalogDbContext(options, GranitDesignTime.CurrentTenant, GranitDesignTime.DataFilter);
     }
 
     public async ValueTask InitializeAsync()


### PR DESCRIPTION
## Summary

- **Persistence**: migrate the three module DbContexts to the new `GranitDbContext` base class (granit-dotnet PRs #2129–#2131). `ICurrentTenant` is now required; the base owns the parameterised multi-tenant filter, conventions pass, and SVO cleanup ordering. `IUserCacheDbContext.FederatedIdentities` (DbSet<FederatedIdentity>) replaces the old `UserCacheEntries`. Design-time factories + integration test fixture use `GranitDesignTime.CurrentTenant` / `DataFilter` stubs.
- **Endpoint renames**: `MapGranitBffEndpoints` → `MapGranitBff`, `MapIdentityUserCacheEndpoints` → `MapGranitIdentityUserCache`.
- **NuGet feed**: switch the Granit.* source from GitHub Packages to GitLab Package Registry (`gitlab.digitaldynamics.be`, project 11), mirroring granit-showcase-dotnet. CI workflows now pass credentials via `NuGetPackageSourceCredentials_GranitGitLab` instead of writing them to `nuget.config` on disk.

## Required repo secrets

The CI workflows now expect:

- `GITLAB_NUGET_USER` — GitLab username (deploy token user)
- `GITLAB_NUGET_TOKEN` — GitLab deploy token with `read_package_registry` scope

The old `GRANIT_PACKAGES_TOKEN` secret can be removed once the new ones are in place.

## Test plan

- [x] `dotnet build GranitMicroservice.slnx` — 0 warnings, 0 errors
- [x] `dotnet test` (unit tests) — 29 passing (AppHost: 8, Catalog: 14, Identity: 2, Notification: 5)
- [ ] CI build + tests pass with the new GitLab secrets
- [ ] `template-validation` workflow scaffolds and builds a fresh solution
- [ ] Integration tests (Testcontainers) pass once `GranitDbContext` ctor change reaches the fixture