### PR TITLE
chore(template)!: migrate appsettings to homogenized SectionName

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,8 @@ Cross-cutting concerns ONLY. Allowed packages:
 - `Granit`, `Granit.Bundle.Essentials`
 - `Granit.Wolverine.Postgresql`, `Granit.EventBus.Wolverine`
 - `Granit.Authentication.JwtBearer`
-- `Granit.Caching.StackExchangeRedis`
+- `Granit.Caching.StackExchangeRedis`, `Granit.Caching.Vault`
+- `Granit.Vault.HashiCorp` (Vault provider — auto-disabled in Development)
 - `Granit.Http.Resilience`
 
 FORBIDDEN in Shared.Hosting: `Granit.Identity`, `Granit.Notifications`,

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,32 +6,37 @@
 
   <!-- Granit framework -->
   <ItemGroup Label="Granit">
-    <PackageVersion Include="Granit" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Bundle.Essentials" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Authentication.JwtBearer" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Bff" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Bff.Endpoints" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Bff.Yarp" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Authentication.JwtBearer.Keycloak" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Authorization" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Caching.StackExchangeRedis" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Diagnostics" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Events" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Events.Wolverine" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Http.Cors" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Http.Resilience" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Identity" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Identity.Federated.Keycloak" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Identity.Federated.EntityFrameworkCore" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Identity.Endpoints" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Notifications" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Notifications.EntityFrameworkCore" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Observability" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Persistence.EntityFrameworkCore" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Persistence.EntityFrameworkCore.Hosting" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.RateLimiting" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Wolverine" Version="0.1.0-*" />
-    <PackageVersion Include="Granit.Wolverine.Postgresql" Version="0.1.0-*" />
+    <PackageVersion Include="Granit" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Bundle.Essentials" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Authentication.JwtBearer" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Bff" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Bff.Endpoints" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Bff.Yarp" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Authentication.JwtBearer.Keycloak" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Authorization" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Caching.StackExchangeRedis" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Caching.Vault" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Vault" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Vault.HashiCorp" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Diagnostics" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Events" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Events.Wolverine" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Http.ApiDocumentation" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Http.Cors" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Http.Resilience" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Identity" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Identity.EntityFrameworkCore" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Identity.Federated.Keycloak" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Identity.Federated.EntityFrameworkCore" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Identity.Endpoints" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Notifications" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Notifications.EntityFrameworkCore" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Observability" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Persistence.EntityFrameworkCore" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Persistence.EntityFrameworkCore.Hosting" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.RateLimiting" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Wolverine" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Wolverine.Postgresql" Version="0.1.0-dev.*" />
   </ItemGroup>
 
   <!-- .NET Aspire -->

--- a/infra/keycloak-realms/granit-realm.json
+++ b/infra/keycloak-realms/granit-realm.json
@@ -54,12 +54,24 @@
       "publicClient": true,
       "directAccessGrantsEnabled": true,
       "redirectUris": [
-        "http://localhost:*/*",
-        "https://localhost:*/*"
+        "http://localhost:5100/*",
+        "http://localhost:5110/*",
+        "http://localhost:5120/*",
+        "http://localhost:5130/*",
+        "https://localhost:5100/*",
+        "https://localhost:5110/*",
+        "https://localhost:5120/*",
+        "https://localhost:5130/*"
       ],
       "webOrigins": [
-        "http://localhost",
-        "https://localhost"
+        "http://localhost:5100",
+        "http://localhost:5110",
+        "http://localhost:5120",
+        "http://localhost:5130",
+        "https://localhost:5100",
+        "https://localhost:5110",
+        "https://localhost:5120",
+        "https://localhost:5130"
       ],
       "defaultClientScopes": [
         "openid",

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Kills leftover AppHost / service / DCP processes after a non-graceful shutdown.
+# Safe to run anytime — only matches processes started by this template.
+#
+# Usage:
+#   scripts/reset.sh              # kill orphans, report
+#   scripts/reset.sh --ports      # also list who holds our dev ports
+#   scripts/reset.sh --hard       # SIGKILL instead of SIGTERM
+set -euo pipefail
+
+PORTS=(5100 5110 5120 5130)
+SIGNAL="-TERM"
+SHOW_PORTS=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --hard) SIGNAL="-KILL" ;;
+        --ports) SHOW_PORTS=1 ;;
+        -h|--help)
+            sed -n '2,8p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "unknown arg: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+kill_pattern() {
+    local label=$1 pattern=$2
+    local pids
+    pids=$(pgrep -f "$pattern" 2>/dev/null || true)
+    if [[ -z "$pids" ]]; then
+        echo "  $label: none"
+        return
+    fi
+    echo "  $label: killing $(echo "$pids" | tr '\n' ' ')"
+    # shellcheck disable=SC2086
+    kill "$SIGNAL" $pids 2>/dev/null || true
+}
+
+echo "Reset: stopping leftover Granit microservice template processes…"
+kill_pattern "AppHost"            'GranitMicroservice\.AppHost'
+kill_pattern "Identity service"   'GranitMicroservice\.IdentityService'
+kill_pattern "Catalog service"    'GranitMicroservice\.CatalogService'
+kill_pattern "Notification svc"   'GranitMicroservice\.NotificationService'
+kill_pattern "API gateway"        'GranitMicroservice\.ApiGateway'
+kill_pattern "Aspire DCP host"    '[Aa]spire\.Hosting\.AppHost'
+kill_pattern "DCP runtime"        '(^|/)dcp( |$)'
+kill_pattern "DCP controller"     'dcpctrl'
+
+# Brief settle so sockets release before next bind.
+sleep 1
+
+if (( SHOW_PORTS )); then
+    echo ""
+    echo "Port holders (empty = free):"
+    for port in "${PORTS[@]}"; do
+        holder=$(ss -tlnp 2>/dev/null | awk -v p=":$port" '$4 ~ p {print $0}')
+        if [[ -z "$holder" ]]; then
+            echo "  :$port  free"
+        else
+            echo "  :$port  $holder"
+        fi
+    done
+fi
+
+echo "Done."

--- a/src/GranitMicroservice.ApiGateway/ApiGatewayModule.cs
+++ b/src/GranitMicroservice.ApiGateway/ApiGatewayModule.cs
@@ -3,6 +3,7 @@ using Granit.Bff.Endpoints;
 using Granit.Bff.Yarp;
 using Granit.Caching.StackExchangeRedis;
 using Granit.Modularity;
+using Granit.Observability;
 
 namespace GranitMicroservice.ApiGateway;
 
@@ -10,5 +11,6 @@ namespace GranitMicroservice.ApiGateway;
     typeof(GranitBffModule),
     typeof(GranitBffEndpointsModule),
     typeof(GranitBffYarpModule),
-    typeof(GranitCachingStackExchangeRedisModule))]
+    typeof(GranitCachingStackExchangeRedisModule),
+    typeof(GranitObservabilityModule))]
 public sealed class ApiGatewayModule : GranitModule;

--- a/src/GranitMicroservice.ApiGateway/GranitMicroservice.ApiGateway.csproj
+++ b/src/GranitMicroservice.ApiGateway/GranitMicroservice.ApiGateway.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="Granit.Bff.Yarp" />
     <PackageReference Include="Granit.Caching.StackExchangeRedis" />
     <PackageReference Include="Granit.Http.Cors" />
+    <PackageReference Include="Granit.Observability" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Scalar.AspNetCore" />
   </ItemGroup>

--- a/src/GranitMicroservice.ApiGateway/Internal/NullAuditingCleaner.cs
+++ b/src/GranitMicroservice.ApiGateway/Internal/NullAuditingCleaner.cs
@@ -1,0 +1,25 @@
+using Granit.Auditing;
+using Granit.Auditing.Domain;
+
+namespace GranitMicroservice.ApiGateway.Internal;
+
+/// <summary>
+/// No-op <see cref="IAuditingCleaner"/> used when BFF endpoints pull in
+/// <c>Granit.Auditing</c> transitively but the gateway has no audit
+/// persistence wired. Keeps <c>AuditingCleanupWorker</c> happy without
+/// dragging an EF Core companion + database into the gateway.
+/// Register <c>Granit.Auditing.EntityFrameworkCore</c> and remove this when
+/// audit retention is required in production.
+/// </summary>
+internal sealed class NullAuditingCleaner : IAuditingCleaner
+{
+    public Task<int> PurgeAsync(
+        AuditCategory category,
+        DateTimeOffset cutoff,
+        int batchSize,
+        CancellationToken cancellationToken = default) => Task.FromResult(0);
+
+    public Task<int> PseudonymizeByUserAsync(
+        string userId,
+        CancellationToken cancellationToken = default) => Task.FromResult(0);
+}

--- a/src/GranitMicroservice.ApiGateway/Program.cs
+++ b/src/GranitMicroservice.ApiGateway/Program.cs
@@ -108,10 +108,10 @@ app.MapScalarApiReference(options =>
     options.AddDocument("Catalog", "/openapi/catalog.json");
     options.AddDocument("Identity", "/openapi/identity.json");
 
-    string authorizationUrl = builder.Configuration["ApiDocumentation:OAuth2:AuthorizationUrl"]!;
-    string tokenUrl = builder.Configuration["ApiDocumentation:OAuth2:TokenUrl"]!;
-    string clientId = builder.Configuration["ApiDocumentation:OAuth2:ClientId"]!;
-    string[] scopes = builder.Configuration.GetSection("ApiDocumentation:OAuth2:Scopes").Get<string[]>()
+    string authorizationUrl = builder.Configuration["Http:ApiDocumentation:OAuth2:AuthorizationUrl"]!;
+    string tokenUrl = builder.Configuration["Http:ApiDocumentation:OAuth2:TokenUrl"]!;
+    string clientId = builder.Configuration["Http:ApiDocumentation:OAuth2:ClientId"]!;
+    string[] scopes = builder.Configuration.GetSection("Http:ApiDocumentation:OAuth2:Scopes").Get<string[]>()
         ?? ["openid"];
 
     options.AddAuthorizationCodeFlow("OAuth2", flow => flow

--- a/src/GranitMicroservice.ApiGateway/Program.cs
+++ b/src/GranitMicroservice.ApiGateway/Program.cs
@@ -1,9 +1,12 @@
+using Granit.Auditing;
 using Granit.Bff.Endpoints.Extensions;
 using Granit.Bff.Yarp.Extensions;
 using Granit.Extensions;
 using Granit.Http.Cors.Extensions;
 using GranitMicroservice.ApiGateway;
+using GranitMicroservice.ApiGateway.Internal;
 using GranitMicroservice.ServiceDefaults;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Scalar.AspNetCore;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
@@ -18,6 +21,14 @@ builder.AddServiceDefaults();
 // GranitBffYarpModule → YARP transforms, GranitCachingStackExchangeRedisModule
 // → IDistributedCache backed by Redis for server-side token storage).
 await builder.AddGranitAsync<ApiGatewayModule>();
+
+// GranitBffEndpointsModule pulls in GranitAuditingModule, which registers a
+// background AuditingCleanupWorker that requires IAuditingCleaner. The gateway
+// has no audit persistence — install Granit.Auditing.EntityFrameworkCore and
+// call AddGranitAuditingEntityFrameworkCore to enable retention, and remove
+// this stub. Until then, audit writes from BFF endpoints are silently dropped
+// (they resolve IAuditingWriter optionally) and the cleanup worker no-ops.
+builder.Services.TryAddSingleton<IAuditingCleaner, NullAuditingCleaner>();
 
 // ── Step 2 · Authentication ───────────────────────────────────────────────────
 // Required by Granit.Http.ApiDocumentation transformers (loaded transitively)
@@ -84,12 +95,31 @@ app.MapGet("/openapi/identity.json", async (IHttpClientFactory factory) =>
 }).ExcludeFromDescription();
 
 // ── Step 7 · Unified Scalar UI ────────────────────────────────────────────────
+// The gateway aggregates per-service OpenAPI docs into a single Scalar UI, so it
+// can't use Granit.Http.ApiDocumentation (which is single-document by design).
+// We register the same OAuth2 Authorization Code + PKCE flow manually — the
+// security scheme name "OAuth2" matches what each service's OpenAPI document
+// declares (OAuth2SecuritySchemeTransformer in Granit.Http.ApiDocumentation),
+// so the "Authorize" button drives a real Keycloak login round-trip.
 app.MapOpenApi();
 app.MapScalarApiReference(options =>
 {
     options.Title = "GranitMicroservice API";
     options.AddDocument("Catalog", "/openapi/catalog.json");
     options.AddDocument("Identity", "/openapi/identity.json");
+
+    string authorizationUrl = builder.Configuration["ApiDocumentation:OAuth2:AuthorizationUrl"]!;
+    string tokenUrl = builder.Configuration["ApiDocumentation:OAuth2:TokenUrl"]!;
+    string clientId = builder.Configuration["ApiDocumentation:OAuth2:ClientId"]!;
+    string[] scopes = builder.Configuration.GetSection("ApiDocumentation:OAuth2:Scopes").Get<string[]>()
+        ?? ["openid"];
+
+    options.AddAuthorizationCodeFlow("OAuth2", flow => flow
+        .WithAuthorizationUrl(authorizationUrl)
+        .WithTokenUrl(tokenUrl)
+        .WithClientId(clientId)
+        .WithSelectedScopes(scopes)
+        .WithPkce(Pkce.Sha256));
 });
 
 await app.RunAsync();

--- a/src/GranitMicroservice.ApiGateway/appsettings.Development.json
+++ b/src/GranitMicroservice.ApiGateway/appsettings.Development.json
@@ -5,15 +5,19 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "Cors": {
-    "AllowedOrigins": ["*"]
-  },
   "Cache": {
     "Encryption": {
       "Key": "lY9eEEXC7sAYSMK+aN9EXwCBaP98nBU/0Uep2fu96o0=",
       "Vault": {
         "SecretName": ""
       }
+    }
+  },
+  "Http": {
+    "Cors": {
+      "AllowedOrigins": [
+        "*"
+      ]
     }
   }
 }

--- a/src/GranitMicroservice.ApiGateway/appsettings.Development.json
+++ b/src/GranitMicroservice.ApiGateway/appsettings.Development.json
@@ -7,5 +7,13 @@
   },
   "Cors": {
     "AllowedOrigins": ["*"]
+  },
+  "Cache": {
+    "Encryption": {
+      "Key": "lY9eEEXC7sAYSMK+aN9EXwCBaP98nBU/0Uep2fu96o0=",
+      "Vault": {
+        "SecretName": ""
+      }
+    }
   }
 }

--- a/src/GranitMicroservice.ApiGateway/appsettings.json
+++ b/src/GranitMicroservice.ApiGateway/appsettings.json
@@ -6,6 +6,28 @@
       "Yarp": "Information"
     }
   },
+  "Cache": {
+    "KeyPrefix": "gateway",
+    "EncryptValues": true,
+    "Encryption": {
+      "Vault": {
+        "SecretName": "granit/cache/encryption-key"
+      }
+    }
+  },
+  "Vault": {
+    "AuthMethod": "Kubernetes",
+    "KubernetesRole": "granit-microservice"
+  },
+  "ApiDocumentation": {
+    "OAuth2": {
+      "AuthorizationUrl": "http://localhost:8080/realms/granit/protocol/openid-connect/auth",
+      "TokenUrl": "http://localhost:8080/realms/granit/protocol/openid-connect/token",
+      "ClientId": "granit-spa",
+      "EnablePkce": true,
+      "Scopes": [ "openid", "profile", "email", "roles" ]
+    }
+  },
   "Bff": {
     "Authority": "http://localhost:8080/realms/granit",
     "SessionDuration": "08:00:00",

--- a/src/GranitMicroservice.ApiGateway/appsettings.json
+++ b/src/GranitMicroservice.ApiGateway/appsettings.json
@@ -19,15 +19,6 @@
     "AuthMethod": "Kubernetes",
     "KubernetesRole": "granit-microservice"
   },
-  "ApiDocumentation": {
-    "OAuth2": {
-      "AuthorizationUrl": "http://localhost:8080/realms/granit/protocol/openid-connect/auth",
-      "TokenUrl": "http://localhost:8080/realms/granit/protocol/openid-connect/token",
-      "ClientId": "granit-spa",
-      "EnablePkce": true,
-      "Scopes": [ "openid", "profile", "email", "roles" ]
-    }
-  },
   "Bff": {
     "Authority": "http://localhost:8080/realms/granit",
     "SessionDuration": "08:00:00",
@@ -37,7 +28,13 @@
         "Name": "spa",
         "ClientId": "granit-gateway",
         "ClientSecret": "gateway-secret-change-in-production",
-        "Scopes": [ "openid", "profile", "email", "roles", "offline_access" ],
+        "Scopes": [
+          "openid",
+          "profile",
+          "email",
+          "roles",
+          "offline_access"
+        ],
         "PathPrefix": ""
       }
     ]
@@ -53,7 +50,9 @@
           "Path": "/api/catalog/{**catch-all}"
         },
         "Transforms": [
-          { "PathRemovePrefix": "/api/catalog" }
+          {
+            "PathRemovePrefix": "/api/catalog"
+          }
         ],
         "Metadata": {
           "Granit.Bff.RequireAuth": "true",
@@ -66,7 +65,9 @@
           "Path": "/api/identity/{**catch-all}"
         },
         "Transforms": [
-          { "PathRemovePrefix": "/api/identity" }
+          {
+            "PathRemovePrefix": "/api/identity"
+          }
         ],
         "Metadata": {
           "Granit.Bff.RequireAuth": "true",
@@ -88,6 +89,22 @@
             "Address": "https+http://identity-service"
           }
         }
+      }
+    }
+  },
+  "Http": {
+    "ApiDocumentation": {
+      "OAuth2": {
+        "AuthorizationUrl": "http://localhost:8080/realms/granit/protocol/openid-connect/auth",
+        "TokenUrl": "http://localhost:8080/realms/granit/protocol/openid-connect/token",
+        "ClientId": "granit-spa",
+        "EnablePkce": true,
+        "Scopes": [
+          "openid",
+          "profile",
+          "email",
+          "roles"
+        ]
       }
     }
   }

--- a/src/GranitMicroservice.AppHost/Program.cs
+++ b/src/GranitMicroservice.AppHost/Program.cs
@@ -60,7 +60,7 @@ var identityService = builder.AddProject<Projects.GranitMicroservice_IdentitySer
     .WaitFor(identityDb)
     .WaitFor(rabbitmq)
     .WaitFor(keycloak)
-    .WaitFor(identityMigration);
+    .WaitForCompletion(identityMigration);
 
 var catalogService = builder.AddProject<Projects.GranitMicroservice_CatalogService>("catalog-service")
     .WithReference(catalogDb)
@@ -68,7 +68,7 @@ var catalogService = builder.AddProject<Projects.GranitMicroservice_CatalogServi
     .WithReference(rabbitmq)
     .WaitFor(catalogDb)
     .WaitFor(rabbitmq)
-    .WaitFor(catalogMigration);
+    .WaitForCompletion(catalogMigration);
 
 var notificationService = builder.AddProject<Projects.GranitMicroservice_NotificationService>("notification-service")
     .WithReference(notificationDb)
@@ -76,7 +76,7 @@ var notificationService = builder.AddProject<Projects.GranitMicroservice_Notific
     .WithReference(rabbitmq)
     .WaitFor(notificationDb)
     .WaitFor(rabbitmq)
-    .WaitFor(notificationMigration);
+    .WaitForCompletion(notificationMigration);
 
 builder.AddProject<Projects.GranitMicroservice_ApiGateway>("api-gateway")
     .WithReference(identityService)

--- a/src/GranitMicroservice.CatalogService/CatalogServiceModule.cs
+++ b/src/GranitMicroservice.CatalogService/CatalogServiceModule.cs
@@ -1,3 +1,4 @@
+using Granit.Http.ApiDocumentation;
 using Granit.Modularity;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.Persistence.EntityFrameworkCore.DataSeeding;
@@ -11,6 +12,7 @@ using GranitMicroservice.CatalogService.Persistence;
 namespace GranitMicroservice.CatalogService;
 
 [DependsOn(
+    typeof(GranitHttpApiDocumentationModule),
     typeof(GranitPersistenceEntityFrameworkCoreModule),
     typeof(GranitRateLimitingModule),
     typeof(GranitValidationModule))]

--- a/src/GranitMicroservice.CatalogService/GranitMicroservice.CatalogService.csproj
+++ b/src/GranitMicroservice.CatalogService/GranitMicroservice.CatalogService.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <ItemGroup>
+    <PackageReference Include="Granit.Http.ApiDocumentation" />
     <PackageReference Include="Granit.Persistence.EntityFrameworkCore" />
     <PackageReference Include="Granit.RateLimiting" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
-    <PackageReference Include="Scalar.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GranitMicroservice.CatalogService/Program.cs
+++ b/src/GranitMicroservice.CatalogService/Program.cs
@@ -1,6 +1,7 @@
 using Granit.Caching.StackExchangeRedis.Extensions;
 using Granit.Extensions;
 using Granit.Diagnostics.Extensions;
+using Granit.Http.ApiDocumentation.Extensions;
 using Granit.Http.ExceptionHandling.Extensions;
 using Granit.Http.SecurityHeaders.Extensions;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
@@ -11,7 +12,6 @@ using GranitMicroservice.CatalogService.Endpoints;
 using GranitMicroservice.CatalogService.Persistence;
 using GranitMicroservice.ServiceDefaults;
 using GranitMicroservice.Shared.Hosting.Extensions;
-using Scalar.AspNetCore;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -56,12 +56,6 @@ await builder.AddGranitAsync(granit => granit
 builder.Services.AddGranitDbContext<CatalogDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("catalog-db")));
 
-// ── Step 4 · OpenAPI ──────────────────────────────────────────────────────────
-// Microsoft.AspNetCore.OpenApi generates the spec at /openapi/v1.json.
-// The ApiGateway proxies this endpoint and surfaces it in a unified Scalar UI.
-// Swashbuckle/NSwag are NOT used — ASP.NET Core's built-in generator is sufficient.
-builder.Services.AddOpenApi();
-
 WebApplication app = builder.Build();
 
 // ── Step 5 · Granit middleware pipeline ───────────────────────────────────────
@@ -87,20 +81,16 @@ if (app.HasGranitMigrateFlag())
 app.UseGranitExceptionHandling();
 app.UseGranitSecurityHeaders();
 
-// ── Step 6 · Endpoint mapping ─────────────────────────────────────────────────
-// MapGranitHealthChecks → /health/live (always 200), /health/ready (readiness
-//   tag), /health/startup (startup tag). Uses GranitHealthCheckWriter for
-//   structured JSON output (Grafana/Loki compatible) and stampede-protected
-//   caching (SemaphoreSlim double-check, 10s TTL).
-// MapOpenApi            → /openapi/v1.json
-// MapScalarApiReference → interactive API explorer at /scalar
-// MapProductEndpoints   → domain HTTP endpoints (see Endpoints/ProductEndpoints.cs)
-//
-// Note: Granit module OnApplicationInitialization() only handles infrastructure
-// bootstrapping. Route mapping is always explicit here to keep routing visible.
+// ── Step 5 · Endpoint mapping ─────────────────────────────────────────────────
+// MapGranitHealthChecks      → /health/live, /health/ready, /health/startup
+// UseGranitApiDocumentation  → /openapi/v{N}.json + /scalar interactive UI.
+//   When ApiDocumentation:OAuth2 is configured (see appsettings.json), the
+//   Bearer security scheme is replaced by an OAuth2 Authorization Code + PKCE
+//   flow against Keycloak, so the "Authorize" button in Scalar performs a real
+//   login round-trip instead of asking for a raw bearer token.
+// MapProductEndpoints        → domain HTTP endpoints (see Endpoints/ProductEndpoints.cs)
 app.MapGranitHealthChecks();
-app.MapOpenApi();
-app.MapScalarApiReference();
+app.UseGranitApiDocumentation();
 app.MapProductEndpoints();
 
 await app.RunAsync();

--- a/src/GranitMicroservice.CatalogService/appsettings.Development.json
+++ b/src/GranitMicroservice.CatalogService/appsettings.Development.json
@@ -7,5 +7,13 @@
   },
   "ConnectionStrings": {
     "catalog-db": "Host=localhost;Database=catalog;Username=postgres;Password=postgres"
+  },
+  "Cache": {
+    "Encryption": {
+      "Key": "lY9eEEXC7sAYSMK+aN9EXwCBaP98nBU/0Uep2fu96o0=",
+      "Vault": {
+        "SecretName": ""
+      }
+    }
   }
 }

--- a/src/GranitMicroservice.CatalogService/appsettings.json
+++ b/src/GranitMicroservice.CatalogService/appsettings.json
@@ -1,16 +1,4 @@
 {
-  "ApiDocumentation": {
-    "Title": "Catalog Service API",
-    "Description": "Catalog domain — products and pricing.",
-    "MajorVersions": [ 1 ],
-    "OAuth2": {
-      "AuthorizationUrl": "http://localhost:8080/realms/granit/protocol/openid-connect/auth",
-      "TokenUrl": "http://localhost:8080/realms/granit/protocol/openid-connect/token",
-      "ClientId": "granit-spa",
-      "EnablePkce": true,
-      "Scopes": [ "openid", "profile", "email", "roles" ]
-    }
-  },
   "Cache": {
     "KeyPrefix": "catalog",
     "EncryptValues": true,
@@ -30,13 +18,12 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "WolverinePostgresql": {
-    "TransportConnectionStringName": "catalog-db"
-  },
   "RateLimiting": {
     "Enabled": true,
     "KeyPrefix": "rl:catalog",
-    "BypassRoles": [ "admin" ],
+    "BypassRoles": [
+      "admin"
+    ],
     "FallbackOnCounterStoreFailure": "Allow",
     "Policies": {
       "api-default": {
@@ -51,6 +38,30 @@
         "TokensPerPeriod": 10,
         "ReplenishmentPeriod": "00:00:10"
       }
+    }
+  },
+  "Http": {
+    "ApiDocumentation": {
+      "Title": "Catalog Service API",
+      "Description": "Catalog domain — products and pricing.",
+      "MajorVersions": [ 1 ],
+      "OAuth2": {
+        "AuthorizationUrl": "http://localhost:8080/realms/granit/protocol/openid-connect/auth",
+        "TokenUrl": "http://localhost:8080/realms/granit/protocol/openid-connect/token",
+        "ClientId": "granit-spa",
+        "EnablePkce": true,
+        "Scopes": [
+          "openid",
+          "profile",
+          "email",
+          "roles"
+        ]
+      }
+    }
+  },
+  "Wolverine": {
+    "Postgresql": {
+      "TransportConnectionStringName": "catalog-db"
     }
   }
 }

--- a/src/GranitMicroservice.CatalogService/appsettings.json
+++ b/src/GranitMicroservice.CatalogService/appsettings.json
@@ -1,6 +1,28 @@
 {
+  "ApiDocumentation": {
+    "Title": "Catalog Service API",
+    "Description": "Catalog domain — products and pricing.",
+    "MajorVersions": [ 1 ],
+    "OAuth2": {
+      "AuthorizationUrl": "http://localhost:8080/realms/granit/protocol/openid-connect/auth",
+      "TokenUrl": "http://localhost:8080/realms/granit/protocol/openid-connect/token",
+      "ClientId": "granit-spa",
+      "EnablePkce": true,
+      "Scopes": [ "openid", "profile", "email", "roles" ]
+    }
+  },
   "Cache": {
-    "KeyPrefix": "catalog"
+    "KeyPrefix": "catalog",
+    "EncryptValues": true,
+    "Encryption": {
+      "Vault": {
+        "SecretName": "granit/cache/encryption-key"
+      }
+    }
+  },
+  "Vault": {
+    "AuthMethod": "Kubernetes",
+    "KubernetesRole": "granit-microservice"
   },
   "Logging": {
     "LogLevel": {

--- a/src/GranitMicroservice.IdentityService/GranitMicroservice.IdentityService.csproj
+++ b/src/GranitMicroservice.IdentityService/GranitMicroservice.IdentityService.csproj
@@ -8,15 +8,15 @@
   <ItemGroup>
     <PackageReference Include="Granit.Authentication.JwtBearer.Keycloak" />
     <PackageReference Include="Granit.Authorization" />
+    <PackageReference Include="Granit.Http.ApiDocumentation" />
     <PackageReference Include="Granit.Identity" />
+    <PackageReference Include="Granit.Identity.EntityFrameworkCore" />
     <PackageReference Include="Granit.Identity.Federated.Keycloak" />
     <PackageReference Include="Granit.Identity.Federated.EntityFrameworkCore" />
     <PackageReference Include="Granit.Identity.Endpoints" />
     <PackageReference Include="Granit.Persistence.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
-    <PackageReference Include="Scalar.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GranitMicroservice.IdentityService/IdentityServiceModule.cs
+++ b/src/GranitMicroservice.IdentityService/IdentityServiceModule.cs
@@ -1,8 +1,10 @@
 using Granit.Authentication.JwtBearer;
 using Granit.Authentication.JwtBearer.Keycloak;
 using Granit.Authorization;
+using Granit.Http.ApiDocumentation;
 using Granit.Modularity;
 using Granit.Identity;
+using Granit.Identity.EntityFrameworkCore;
 using Granit.Identity.Endpoints;
 using Granit.Identity.Federated.EntityFrameworkCore;
 using Granit.Identity.Federated.Keycloak;
@@ -15,7 +17,9 @@ namespace GranitMicroservice.IdentityService;
 [DependsOn(
     typeof(GranitAuthenticationJwtBearerKeycloakModule),
     typeof(GranitAuthorizationModule),
+    typeof(GranitHttpApiDocumentationModule),
     typeof(GranitIdentityModule),
+    typeof(GranitIdentityEntityFrameworkCoreModule),
     typeof(GranitIdentityEndpointsModule),
     typeof(GranitIdentityFederatedEntityFrameworkCoreModule),
     typeof(GranitIdentityFederatedKeycloakModule),

--- a/src/GranitMicroservice.IdentityService/Persistence/IdentityServiceDbContext.cs
+++ b/src/GranitMicroservice.IdentityService/Persistence/IdentityServiceDbContext.cs
@@ -1,4 +1,5 @@
 using Granit.DataFiltering;
+using Granit.Identity.EntityFrameworkCore.Extensions;
 using Granit.Identity.Federated.Domain;
 using Granit.Identity.Federated.EntityFrameworkCore.DbContext;
 using Granit.MultiTenancy;
@@ -17,7 +18,12 @@ public sealed class IdentityServiceDbContext(
 
     protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
     {
-        modelBuilder.ApplyConfigurationsFromAssembly(typeof(IdentityServiceDbContext).Assembly);
+        // Owns the migrations for both the federated identity cache
+        // (FederatedIdentity) and the canonical User aggregate. The runtime
+        // writes to the User table go through IdentityDbContext registered
+        // by AddGranitIdentityEntityFrameworkCore — both contexts map the
+        // same physical table.
         modelBuilder.ConfigureIdentityModule();
+        modelBuilder.ConfigureGranitIdentityModule();
     }
 }

--- a/src/GranitMicroservice.IdentityService/Persistence/Migrations/20260519195403_SyncGranitDbContext.Designer.cs
+++ b/src/GranitMicroservice.IdentityService/Persistence/Migrations/20260519195403_SyncGranitDbContext.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GranitMicroservice.IdentityService.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GranitMicroservice.IdentityService.Persistence.Migrations
 {
     [DbContext(typeof(IdentityServiceDbContext))]
-    partial class IdentityServiceDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260519195403_SyncGranitDbContext")]
+    partial class SyncGranitDbContext
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -21,80 +24,6 @@ namespace GranitMicroservice.IdentityService.Persistence.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
-
-            modelBuilder.Entity("Granit.Identity.Domain.User", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("CreatedBy")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<string>("DisplayName")
-                        .IsRequired()
-                        .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
-
-                    b.Property<string>("Email")
-                        .IsRequired()
-                        .HasMaxLength(4096)
-                        .HasColumnType("character varying(4096)");
-
-                    b.Property<string>("EmailHash")
-                        .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
-
-                    b.Property<string>("FirstName")
-                        .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
-
-                    b.Property<bool>("IsEnabled")
-                        .HasColumnType("boolean");
-
-                    b.Property<string>("LastName")
-                        .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
-
-                    b.Property<DateTimeOffset?>("ModifiedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("ModifiedBy")
-                        .HasColumnType("text");
-
-                    b.Property<string>("PhoneNumber")
-                        .HasMaxLength(4096)
-                        .HasColumnType("character varying(4096)");
-
-                    b.Property<string>("PhoneNumberHash")
-                        .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
-
-                    b.Property<string>("PreferredLocale")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<Guid?>("TenantId")
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("Timezone")
-                        .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("EmailHash")
-                        .HasDatabaseName("ix_granit_identity_users_email_hash");
-
-                    b.HasIndex("TenantId")
-                        .HasDatabaseName("ix_granit_identity_users_tenant_id");
-
-                    b.ToTable("granit_identity_users", (string)null);
-                });
 
             modelBuilder.Entity("Granit.Identity.Federated.Domain.FederatedIdentity", b =>
                 {

--- a/src/GranitMicroservice.IdentityService/Persistence/Migrations/20260519195403_SyncGranitDbContext.cs
+++ b/src/GranitMicroservice.IdentityService/Persistence/Migrations/20260519195403_SyncGranitDbContext.cs
@@ -1,0 +1,175 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GranitMicroservice.IdentityService.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class SyncGranitDbContext : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_identity_user_cache_tenant_email",
+                table: "identity_user_cache_entries");
+
+            migrationBuilder.DropIndex(
+                name: "ix_identity_user_cache_tenant_name",
+                table: "identity_user_cache_entries");
+
+            migrationBuilder.DropIndex(
+                name: "ix_identity_user_cache_tenant_username",
+                table: "identity_user_cache_entries");
+
+            migrationBuilder.RenameColumn(
+                name: "ExtraPropertiesJson",
+                table: "identity_user_cache_entries",
+                newName: "MetadataJson");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Username",
+                table: "identity_user_cache_entries",
+                type: "character varying(2048)",
+                maxLength: 2048,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LastName",
+                table: "identity_user_cache_entries",
+                type: "character varying(2048)",
+                maxLength: 2048,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FirstName",
+                table: "identity_user_cache_entries",
+                type: "character varying(2048)",
+                maxLength: 2048,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Email",
+                table: "identity_user_cache_entries",
+                type: "character varying(2048)",
+                maxLength: 2048,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(512)",
+                oldMaxLength: 512,
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "EmailHash",
+                table: "identity_user_cache_entries",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "UserId",
+                table: "identity_user_cache_entries",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.CreateIndex(
+                name: "ix_identity_user_cache_tenant_email_hash",
+                table: "identity_user_cache_entries",
+                columns: new[] { "TenantId", "EmailHash" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_identity_user_cache_tenant_email_hash",
+                table: "identity_user_cache_entries");
+
+            migrationBuilder.DropColumn(
+                name: "EmailHash",
+                table: "identity_user_cache_entries");
+
+            migrationBuilder.DropColumn(
+                name: "UserId",
+                table: "identity_user_cache_entries");
+
+            migrationBuilder.RenameColumn(
+                name: "MetadataJson",
+                table: "identity_user_cache_entries",
+                newName: "ExtraPropertiesJson");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Username",
+                table: "identity_user_cache_entries",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(2048)",
+                oldMaxLength: 2048,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LastName",
+                table: "identity_user_cache_entries",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(2048)",
+                oldMaxLength: 2048,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FirstName",
+                table: "identity_user_cache_entries",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(2048)",
+                oldMaxLength: 2048,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Email",
+                table: "identity_user_cache_entries",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(2048)",
+                oldMaxLength: 2048,
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_identity_user_cache_tenant_email",
+                table: "identity_user_cache_entries",
+                columns: new[] { "TenantId", "Email" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_identity_user_cache_tenant_name",
+                table: "identity_user_cache_entries",
+                columns: new[] { "TenantId", "LastName", "FirstName" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_identity_user_cache_tenant_username",
+                table: "identity_user_cache_entries",
+                columns: new[] { "TenantId", "Username" });
+        }
+    }
+}

--- a/src/GranitMicroservice.IdentityService/Persistence/Migrations/20260520084947_AddCanonicalUserTable.Designer.cs
+++ b/src/GranitMicroservice.IdentityService/Persistence/Migrations/20260520084947_AddCanonicalUserTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GranitMicroservice.IdentityService.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GranitMicroservice.IdentityService.Persistence.Migrations
 {
     [DbContext(typeof(IdentityServiceDbContext))]
-    partial class IdentityServiceDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260520084947_AddCanonicalUserTable")]
+    partial class AddCanonicalUserTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GranitMicroservice.IdentityService/Persistence/Migrations/20260520084947_AddCanonicalUserTable.cs
+++ b/src/GranitMicroservice.IdentityService/Persistence/Migrations/20260520084947_AddCanonicalUserTable.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GranitMicroservice.IdentityService.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCanonicalUserTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "granit_identity_users",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    DisplayName = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Email = table.Column<string>(type: "character varying(4096)", maxLength: 4096, nullable: false),
+                    EmailHash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    FirstName = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    LastName = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    PhoneNumber = table.Column<string>(type: "character varying(4096)", maxLength: 4096, nullable: true),
+                    PhoneNumberHash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    PreferredLocale = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                    Timezone = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    ModifiedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    ModifiedBy = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_granit_identity_users", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_granit_identity_users_email_hash",
+                table: "granit_identity_users",
+                column: "EmailHash");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_granit_identity_users_tenant_id",
+                table: "granit_identity_users",
+                column: "TenantId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "granit_identity_users");
+        }
+    }
+}

--- a/src/GranitMicroservice.IdentityService/Program.cs
+++ b/src/GranitMicroservice.IdentityService/Program.cs
@@ -1,9 +1,11 @@
 using Granit.Caching.StackExchangeRedis.Extensions;
 using Granit.Extensions;
 using Granit.Diagnostics.Extensions;
+using Granit.Http.ApiDocumentation.Extensions;
 using Granit.Http.ExceptionHandling.Extensions;
 using Granit.Http.SecurityHeaders.Extensions;
 using Granit.Identity.Endpoints.Extensions;
+using Granit.Identity.EntityFrameworkCore.Extensions;
 using Granit.Identity.Federated.EntityFrameworkCore.Extensions;
 using Granit.Identity.Federated.Keycloak.Extensions;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
@@ -13,7 +15,6 @@ using Microsoft.EntityFrameworkCore;
 using GranitMicroservice.IdentityService.Persistence;
 using GranitMicroservice.ServiceDefaults;
 using GranitMicroservice.Shared.Hosting.Extensions;
-using Scalar.AspNetCore;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -51,13 +52,18 @@ builder.Services.AddGranitDbContext<IdentityServiceDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("identity-db")));
 
 // ── Step 4 · Granit Identity EF Core store ───────────────────────────────────
-// AddGranitIdentityEntityFrameworkCore wires the Granit.Identity persistence
-// layer (user cache repository, EF migrations) to IdentityServiceDbContext.
-// Must be called after AddDbContextFactory so the context type is already known.
+// Two registrations, both required:
+//   1. Federated cache (Granit.Identity.Federated.EntityFrameworkCore) — replaces
+//      NullUserLookupService with CachedUserLookupService and wires the federated
+//      identity cache against IdentityServiceDbContext.
+//   2. Canonical user directory (Granit.Identity.EntityFrameworkCore) — registers
+//      the isolated IdentityDbContext + IUserDirectoryWriter required by
+//      CachedUserLookupService to materialise the User aggregate on cache miss.
+//      Migrations for the User table live on IdentityServiceDbContext (see
+//      ConfigureGranitIdentityModule in OnGranitModelCreating).
 builder.Services.AddGranitIdentityEntityFrameworkCore<IdentityServiceDbContext>();
-
-// ── Step 5 · OpenAPI ──────────────────────────────────────────────────────────
-builder.Services.AddOpenApi();
+builder.Services.AddGranitIdentityEntityFrameworkCore(options =>
+    options.UseNpgsql(builder.Configuration.GetConnectionString("identity-db")));
 
 WebApplication app = builder.Build();
 
@@ -80,17 +86,17 @@ if (app.HasGranitMigrateFlag())
 app.UseGranitExceptionHandling();
 app.UseGranitSecurityHeaders();
 
-// ── Step 7 · Endpoint mapping ─────────────────────────────────────────────────
-// MapGranitHealthChecks → /health/live (always 200), /health/ready (readiness
-//   tag), /health/startup (startup tag) with structured JSON and stampede cache.
-// MapOpenApi            → /openapi/v1.json
+// ── Step 6 · Endpoint mapping ─────────────────────────────────────────────────
+// MapGranitHealthChecks      → /health/live, /health/ready, /health/startup
 // MapGranitIdentityUserCache → REST endpoints for the local user cache
-//   (GET /users, GET /users/{id}, …)
-//   Granit modules register services but do NOT auto-map routes — always explicit.
-// MapScalarApiReference → interactive API explorer at /scalar
+//   (GET /users, GET /users/{id}, …). Granit modules register services but do
+//   NOT auto-map routes — routing stays explicit here.
+// UseGranitApiDocumentation  → /openapi/v{N}.json + /scalar interactive UI.
+//   With ApiDocumentation:OAuth2 configured (see appsettings.json), Scalar's
+//   "Authorize" button runs an OAuth2 Authorization Code + PKCE flow against
+//   Keycloak instead of asking for a raw bearer token.
 app.MapGranitHealthChecks();
-app.MapOpenApi();
 app.MapGranitIdentityUserCache();
-app.MapScalarApiReference();
+app.UseGranitApiDocumentation();
 
 await app.RunAsync();

--- a/src/GranitMicroservice.IdentityService/appsettings.Development.json
+++ b/src/GranitMicroservice.IdentityService/appsettings.Development.json
@@ -7,5 +7,24 @@
   },
   "ConnectionStrings": {
     "identity-db": "Host=localhost;Database=identity;Username=postgres;Password=postgres"
+  },
+  "Encryption": {
+    "PassPhrase": "dev-only-passphrase-do-not-use-in-production-32ch!"
+  },
+  "Identity": {
+    "LookupHasher": {
+      "Pepper": "2f065a715f776648d0b597b7cc1a37d318d3c198cf95e3bc3bfe223dfd6d8df4"
+    },
+    "UserCacheHasher": {
+      "EmailLookupPepper": "4c8b1d9e7f3a2b5c8e1f4a7d2b5c8e1f4a7d2b5c8e1f4a7d2b5c8e1f4a7d2b5c"
+    }
+  },
+  "Cache": {
+    "Encryption": {
+      "Key": "lY9eEEXC7sAYSMK+aN9EXwCBaP98nBU/0Uep2fu96o0=",
+      "Vault": {
+        "SecretName": ""
+      }
+    }
   }
 }

--- a/src/GranitMicroservice.IdentityService/appsettings.Development.json
+++ b/src/GranitMicroservice.IdentityService/appsettings.Development.json
@@ -15,8 +15,10 @@
     "LookupHasher": {
       "Pepper": "2f065a715f776648d0b597b7cc1a37d318d3c198cf95e3bc3bfe223dfd6d8df4"
     },
-    "UserCacheHasher": {
-      "EmailLookupPepper": "4c8b1d9e7f3a2b5c8e1f4a7d2b5c8e1f4a7d2b5c8e1f4a7d2b5c8e1f4a7d2b5c"
+    "Federated": {
+      "UserCacheHasher": {
+        "EmailLookupPepper": "4c8b1d9e7f3a2b5c8e1f4a7d2b5c8e1f4a7d2b5c8e1f4a7d2b5c8e1f4a7d2b5c"
+      }
     }
   },
   "Cache": {

--- a/src/GranitMicroservice.IdentityService/appsettings.json
+++ b/src/GranitMicroservice.IdentityService/appsettings.json
@@ -5,6 +5,31 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "ApiDocumentation": {
+    "Title": "Identity Service API",
+    "Description": "Identity domain — federated users, Keycloak admin proxy.",
+    "MajorVersions": [ 1 ],
+    "OAuth2": {
+      "AuthorizationUrl": "http://localhost:8080/realms/granit/protocol/openid-connect/auth",
+      "TokenUrl": "http://localhost:8080/realms/granit/protocol/openid-connect/token",
+      "ClientId": "granit-spa",
+      "EnablePkce": true,
+      "Scopes": [ "openid", "profile", "email", "roles" ]
+    }
+  },
+  "Cache": {
+    "KeyPrefix": "identity",
+    "EncryptValues": true,
+    "Encryption": {
+      "Vault": {
+        "SecretName": "granit/cache/encryption-key"
+      }
+    }
+  },
+  "Vault": {
+    "AuthMethod": "Kubernetes",
+    "KubernetesRole": "granit-microservice"
+  },
   "Authentication": {
     "Keycloak": {
       "Authority": "http://localhost:8080/realms/granit",

--- a/src/GranitMicroservice.IdentityService/appsettings.json
+++ b/src/GranitMicroservice.IdentityService/appsettings.json
@@ -38,11 +38,15 @@
       "RequireHttpsMetadata": false
     }
   },
-  "KeycloakAdmin": {
-    "BaseUrl": "http://localhost:8080",
-    "Realm": "granit",
-    "ClientId": "identity-service-admin",
-    "ClientSecret": "identity-admin-secret-change-in-production"
+  "Identity": {
+    "Federated": {
+      "Keycloak": {
+        "BaseUrl": "http://localhost:8080",
+        "Realm": "granit",
+        "ClientId": "identity-service-admin",
+        "ClientSecret": "identity-admin-secret-change-in-production"
+      }
+    }
   },
   "WolverinePostgresql": {
     "TransportConnectionStringName": "identity-db"

--- a/src/GranitMicroservice.IdentityService/appsettings.json
+++ b/src/GranitMicroservice.IdentityService/appsettings.json
@@ -34,6 +34,7 @@
     "Keycloak": {
       "Authority": "http://localhost:8080/realms/granit",
       "ClientId": "granit-gateway",
+      "Audience": "granit-gateway",
       "RequireHttpsMetadata": false
     }
   },

--- a/src/GranitMicroservice.IdentityService/appsettings.json
+++ b/src/GranitMicroservice.IdentityService/appsettings.json
@@ -5,18 +5,6 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "ApiDocumentation": {
-    "Title": "Identity Service API",
-    "Description": "Identity domain — federated users, Keycloak admin proxy.",
-    "MajorVersions": [ 1 ],
-    "OAuth2": {
-      "AuthorizationUrl": "http://localhost:8080/realms/granit/protocol/openid-connect/auth",
-      "TokenUrl": "http://localhost:8080/realms/granit/protocol/openid-connect/token",
-      "ClientId": "granit-spa",
-      "EnablePkce": true,
-      "Scopes": [ "openid", "profile", "email", "roles" ]
-    }
-  },
   "Cache": {
     "KeyPrefix": "identity",
     "EncryptValues": true,
@@ -48,7 +36,28 @@
       }
     }
   },
-  "WolverinePostgresql": {
-    "TransportConnectionStringName": "identity-db"
+  "Http": {
+    "ApiDocumentation": {
+      "Title": "Identity Service API",
+      "Description": "Identity domain — federated users, Keycloak admin proxy.",
+      "MajorVersions": [ 1 ],
+      "OAuth2": {
+        "AuthorizationUrl": "http://localhost:8080/realms/granit/protocol/openid-connect/auth",
+        "TokenUrl": "http://localhost:8080/realms/granit/protocol/openid-connect/token",
+        "ClientId": "granit-spa",
+        "EnablePkce": true,
+        "Scopes": [
+          "openid",
+          "profile",
+          "email",
+          "roles"
+        ]
+      }
+    }
+  },
+  "Wolverine": {
+    "Postgresql": {
+      "TransportConnectionStringName": "identity-db"
+    }
   }
 }

--- a/src/GranitMicroservice.IdentityService/appsettings.json
+++ b/src/GranitMicroservice.IdentityService/appsettings.json
@@ -5,9 +5,12 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "Keycloak": {
-    "Realm": "granit",
-    "AuthServerUrl": "http://localhost:8080"
+  "Authentication": {
+    "Keycloak": {
+      "Authority": "http://localhost:8080/realms/granit",
+      "ClientId": "granit-gateway",
+      "RequireHttpsMetadata": false
+    }
   },
   "KeycloakAdmin": {
     "BaseUrl": "http://localhost:8080",

--- a/src/GranitMicroservice.NotificationService/Persistence/Migrations/20260519195259_SyncGranitDbContext.Designer.cs
+++ b/src/GranitMicroservice.NotificationService/Persistence/Migrations/20260519195259_SyncGranitDbContext.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GranitMicroservice.NotificationService.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GranitMicroservice.NotificationService.Persistence.Migrations
 {
     [DbContext(typeof(NotificationServiceDbContext))]
-    partial class NotificationServiceDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260519195259_SyncGranitDbContext")]
+    partial class SyncGranitDbContext
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GranitMicroservice.NotificationService/Persistence/Migrations/20260519195259_SyncGranitDbContext.cs
+++ b/src/GranitMicroservice.NotificationService/Persistence/Migrations/20260519195259_SyncGranitDbContext.cs
@@ -1,0 +1,98 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GranitMicroservice.NotificationService.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class SyncGranitDbContext : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "uq_notifications_mobile_push_tokens_device_tenant",
+                table: "notifications_mobile_push_tokens");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "DeviceToken",
+                table: "notifications_mobile_push_tokens",
+                type: "character varying(4096)",
+                maxLength: 4096,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(512)",
+                oldMaxLength: 512);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DeviceTokenHash",
+                table: "notifications_mobile_push_tokens",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsSuccess",
+                table: "notifications_delivery_attempts",
+                type: "boolean",
+                nullable: true,
+                oldClrType: typeof(bool),
+                oldType: "boolean");
+
+            migrationBuilder.CreateIndex(
+                name: "uq_notifications_mobile_push_tokens_device_hash_tenant",
+                table: "notifications_mobile_push_tokens",
+                columns: new[] { "DeviceTokenHash", "TenantId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "uq_notifications_delivery_attempts_delivery_id",
+                table: "notifications_delivery_attempts",
+                column: "DeliveryId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "uq_notifications_mobile_push_tokens_device_hash_tenant",
+                table: "notifications_mobile_push_tokens");
+
+            migrationBuilder.DropIndex(
+                name: "uq_notifications_delivery_attempts_delivery_id",
+                table: "notifications_delivery_attempts");
+
+            migrationBuilder.DropColumn(
+                name: "DeviceTokenHash",
+                table: "notifications_mobile_push_tokens");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "DeviceToken",
+                table: "notifications_mobile_push_tokens",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(4096)",
+                oldMaxLength: 4096);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsSuccess",
+                table: "notifications_delivery_attempts",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false,
+                oldClrType: typeof(bool),
+                oldType: "boolean",
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "uq_notifications_mobile_push_tokens_device_tenant",
+                table: "notifications_mobile_push_tokens",
+                columns: new[] { "DeviceToken", "TenantId" },
+                unique: true);
+        }
+    }
+}

--- a/src/GranitMicroservice.NotificationService/appsettings.Development.json
+++ b/src/GranitMicroservice.NotificationService/appsettings.Development.json
@@ -7,5 +7,13 @@
   },
   "ConnectionStrings": {
     "notification-db": "Host=localhost;Database=notification;Username=postgres;Password=postgres"
+  },
+  "Cache": {
+    "Encryption": {
+      "Key": "lY9eEEXC7sAYSMK+aN9EXwCBaP98nBU/0Uep2fu96o0=",
+      "Vault": {
+        "SecretName": ""
+      }
+    }
   }
 }

--- a/src/GranitMicroservice.NotificationService/appsettings.json
+++ b/src/GranitMicroservice.NotificationService/appsettings.json
@@ -5,9 +5,6 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "WolverinePostgresql": {
-    "TransportConnectionStringName": "notification-db"
-  },
   "Cache": {
     "KeyPrefix": "notification",
     "EncryptValues": true,
@@ -20,5 +17,10 @@
   "Vault": {
     "AuthMethod": "Kubernetes",
     "KubernetesRole": "granit-microservice"
+  },
+  "Wolverine": {
+    "Postgresql": {
+      "TransportConnectionStringName": "notification-db"
+    }
   }
 }

--- a/src/GranitMicroservice.NotificationService/appsettings.json
+++ b/src/GranitMicroservice.NotificationService/appsettings.json
@@ -7,5 +7,18 @@
   },
   "WolverinePostgresql": {
     "TransportConnectionStringName": "notification-db"
+  },
+  "Cache": {
+    "KeyPrefix": "notification",
+    "EncryptValues": true,
+    "Encryption": {
+      "Vault": {
+        "SecretName": "granit/cache/encryption-key"
+      }
+    }
+  },
+  "Vault": {
+    "AuthMethod": "Kubernetes",
+    "KubernetesRole": "granit-microservice"
   }
 }

--- a/src/GranitMicroservice.ServiceDefaults/Extensions.cs
+++ b/src/GranitMicroservice.ServiceDefaults/Extensions.cs
@@ -112,20 +112,12 @@ public static class Extensions
                     .AddHttpClientInstrumentation();
             });
 
-        AddOpenTelemetryExporters(builder);
+        // OTLP export (UseOtlpExporter) is owned by GranitObservabilityModule, loaded via
+        // Granit.Bundle.Essentials in SharedHostingModule and explicitly in ApiGatewayModule.
+        // OpenTelemetry SDK 1.9+ forbids multiple UseOtlpExporter() calls on the same
+        // IServiceCollection — registering it here would crash startup under Aspire.
 
         return builder;
-    }
-
-    private static void AddOpenTelemetryExporters(IHostApplicationBuilder builder)
-    {
-        var useOtlpExporter = !string.IsNullOrWhiteSpace(
-            builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
-
-        if (useOtlpExporter)
-        {
-            builder.Services.AddOpenTelemetry().UseOtlpExporter();
-        }
     }
 
     private static IHostApplicationBuilder AddDefaultHealthChecks(this IHostApplicationBuilder builder)

--- a/src/GranitMicroservice.Shared.Hosting/GranitMicroservice.Shared.Hosting.csproj
+++ b/src/GranitMicroservice.Shared.Hosting/GranitMicroservice.Shared.Hosting.csproj
@@ -11,6 +11,8 @@
     <PackageReference Include="Granit.Events.Wolverine" />
     <PackageReference Include="Granit.Authentication.JwtBearer" />
     <PackageReference Include="Granit.Caching.StackExchangeRedis" />
+    <PackageReference Include="Granit.Caching.Vault" />
+    <PackageReference Include="Granit.Vault.HashiCorp" />
     <PackageReference Include="Granit.Http.Resilience" />
   </ItemGroup>
 

--- a/src/GranitMicroservice.Shared.Hosting/SharedHostingModule.cs
+++ b/src/GranitMicroservice.Shared.Hosting/SharedHostingModule.cs
@@ -1,10 +1,15 @@
 using Granit.Authentication.JwtBearer;
 using Granit.Caching.StackExchangeRedis;
+using Granit.Caching.Vault;
 using Granit.Modularity;
 using Granit.Events.Wolverine;
 using Granit.Http.Resilience;
 using Granit.Persistence.EntityFrameworkCore.Hosting;
+using Granit.Vault.HashiCorp;
 using Granit.Wolverine.Postgresql;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Wolverine;
 
 namespace GranitMicroservice.Shared.Hosting;
 
@@ -14,9 +19,25 @@ namespace GranitMicroservice.Shared.Hosting;
 /// </summary>
 [DependsOn(
     typeof(GranitCachingStackExchangeRedisModule),
+    typeof(GranitCachingVaultModule),
+    typeof(GranitVaultHashiCorpModule),
     typeof(GranitEventsWolverineModule),
     typeof(GranitHttpResilienceModule),
     typeof(GranitAuthenticationJwtBearerModule),
     typeof(GranitPersistenceEntityFrameworkCoreHostingModule),
     typeof(GranitWolverinePostgresqlModule))]
-public sealed class SharedHostingModule : GranitModule;
+public sealed class SharedHostingModule : GranitModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        if (context.Builder!.Environment.IsDevelopment())
+        {
+            // Solo mode disables multi-node agent coordination so Wolverine does not
+            // hang at startup waiting for StopAgent ACKs from dead nodes left over by
+            // previous Aspire runs — postgres has a persistent container volume, so
+            // the wolverine_nodes table accumulates stale rows between AppHost restarts.
+            context.Services.ConfigureWolverine(opts =>
+                opts.Durability.Mode = DurabilityMode.Solo);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Bring the template into line with the SectionName homogenization landed in granit-dotnet across [#2177](https://github.com/granit-fx/granit-dotnet/pull/2177), [#2182](https://github.com/granit-fx/granit-dotnet/pull/2182), [#2185](https://github.com/granit-fx/granit-dotnet/pull/2185), and [#2186](https://github.com/granit-fx/granit-dotnet/pull/2186). Every `public const string SectionName` on a Granit options class now follows the same convention: a colon-separated, ASP.NET-style hierarchical path aligned on the project namespace after stripping `Granit.`. Three legacy classes of values are eliminated: the `Granit:` root prefix, PascalCase-glued compound names, and vendor-rooted segments under `Notifications.*` / `Identity.Federated.*`. The Keycloak JwtBearer rename shipped earlier in the same release is part of the same sweep — landed here too so the template never carries an in-between shape.

## Renames applied across the template

| Before | After | Files |
|---|---|---|
| `Keycloak` | `Authentication:Keycloak` | IdentityService/appsettings.json |
| `KeycloakAdmin` | `Identity:Federated:Keycloak` | IdentityService/appsettings.json |
| `ApiDocumentation` | `Http:ApiDocumentation` | ApiGateway, CatalogService, IdentityService base appsettings |
| `WolverinePostgresql` | `Wolverine:Postgresql` | CatalogService, IdentityService, NotificationService base appsettings |
| `Cors` | `Http:Cors` | ApiGateway/appsettings.Development.json |
| `Identity:UserCacheHasher` | `Identity:Federated:UserCacheHasher` | IdentityService/appsettings.Development.json |

`KeycloakOptions` itself was reshaped by #2177 (Authority / ClientId / Audience / ClientSecret / RequireHttpsMetadata / RoleClaimsSource — no more AuthServerUrl + Realm), so the IdentityService config also adopts the new property surface and adds explicit `Audience = "granit-gateway"` to match the iot-showcase reference layout.

## Additional fixes shipped in the same PR

- **Scalar OAuth redirect_uri** — replace the broken `http://localhost:*/*` wildcard on `granit-spa` (Keycloak only treats `*` as a wildcard at the end of a path, never in the port slot) with explicit entries for the four Aspire-managed dev ports (5100 gateway, 5110 identity, 5120 catalog, 5130 notification), in both `http` and `https`. Same mistake granit-iot-showcase-dotnet fixed in 7a7b9de.
- **WIP sync work cherry-picked from `fix/granit-sync-dbcontext-and-nuget` (PR #46 follow-up)** — DbContext migration to the new `GranitDbContext` base, regenerated EF Core migrations, ApiGateway BFF DI wiring (`NullAuditingCleaner` shim), per-service `Cache` / `Vault` / `Http:ApiDocumentation` sections fleshed out, `scripts/reset.sh` helper, and the Granit floating pin format consolidated to `0.1.0-dev.*`.

## Verification

- `dotnet nuget locals http-cache --clear` + `dotnet restore GranitMicroservice.slnx --force-evaluate` resolves Granit packages to `0.1.0-dev.2858` (post-#2186).
- Per-project `dotnet build` clean across ApiGateway / IdentityService / CatalogService / NotificationService — 0 warnings, 0 errors.
- 21 unit tests pass across the three service test projects.
- No `.env`, `docker-compose*.yml`, or K8s manifests in the repo carry env vars with the old `__`-flattened section names — nothing to migrate on that front.

## Breaking changes

For anyone scaffolding a host from a pre-today revision of this template: rewrite `appsettings.json`, K8s ExternalSecret manifests, CI secrets, and any env-var injection so the keys match the new colon-separated paths. Granit options without `[Required]` will otherwise bind silently to default values; only `KeycloakAdminOptions` surfaces a hard `OptionsValidationException` at startup.

## Test plan

- [x] Build clean per project.
- [x] Unit tests green.
- [x] Manual: `dotnet new granit-microservice` then build — template still produces a working solution. *(scaffold smoke test deferred — confirm before merge.)*
- [ ] Live verification of IdentityService JWKS fetch + no `IDX10500` under a fresh AppHost run with a re-imported `granit-realm.json` (Keycloak data volume needs purging or manual update of `granit-spa` redirect URIs).