### PR TITLE
feat(notifications): integrate Mailpit + wire SMTP email channel

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,6 +30,8 @@
     <PackageVersion Include="Granit.Identity.Federated.EntityFrameworkCore" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Identity.Endpoints" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Notifications" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Notifications.Email" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Notifications.Email.Smtp" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Notifications.EntityFrameworkCore" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Observability" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Persistence.EntityFrameworkCore" Version="0.1.0-dev.*" />

--- a/src/GranitMicroservice.AppHost/Program.cs
+++ b/src/GranitMicroservice.AppHost/Program.cs
@@ -27,6 +27,15 @@ var keycloak = builder.AddKeycloak("keycloak", port: 8080)
     .WithEnvironment("KC_HOSTNAME_STRICT_HTTPS", "false")
     .WithEnvironment("KC_PROXY", "edge");
 
+// Local SMTP sink — captures emails sent by NotificationService and exposes a
+// web UI on http://localhost:8025. Add Granit.Notifications.Email[.Smtp] +
+// AddGranitNotificationsEmail()/EmailSmtp() in NotificationServiceModule to
+// route notifications here.
+var mailpit = builder.AddContainer("mailpit", "axllent/mailpit")
+    .WithLifetime(ContainerLifetime.Persistent)
+    .WithHttpEndpoint(port: 8025, targetPort: 8025, name: "ui")
+    .WithEndpoint(port: 1025, targetPort: 1025, name: "smtp", scheme: "tcp");
+
 // Migrations — run --migrate and exit before services start
 var identityMigration = builder.AddProject<Projects.GranitMicroservice_IdentityService>("identity-migration")
     .WithReference(identityDb)
@@ -76,6 +85,7 @@ var notificationService = builder.AddProject<Projects.GranitMicroservice_Notific
     .WithReference(rabbitmq)
     .WaitFor(notificationDb)
     .WaitFor(rabbitmq)
+    .WaitFor(mailpit)
     .WaitForCompletion(notificationMigration);
 
 builder.AddProject<Projects.GranitMicroservice_ApiGateway>("api-gateway")

--- a/src/GranitMicroservice.NotificationService/GranitMicroservice.NotificationService.csproj
+++ b/src/GranitMicroservice.NotificationService/GranitMicroservice.NotificationService.csproj
@@ -7,6 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Granit.Notifications" />
+    <PackageReference Include="Granit.Notifications.Email" />
+    <PackageReference Include="Granit.Notifications.Email.Smtp" />
     <PackageReference Include="Granit.Notifications.EntityFrameworkCore" />
     <PackageReference Include="Granit.Persistence.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" />

--- a/src/GranitMicroservice.NotificationService/NotificationServiceModule.cs
+++ b/src/GranitMicroservice.NotificationService/NotificationServiceModule.cs
@@ -1,5 +1,7 @@
 using Granit.Modularity;
 using Granit.Notifications;
+using Granit.Notifications.Email.Extensions;
+using Granit.Notifications.Email.Smtp.Extensions;
 using Granit.Notifications.Extensions;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.Persistence.EntityFrameworkCore.Hosting;
@@ -13,6 +15,14 @@ namespace GranitMicroservice.NotificationService;
     typeof(GranitPersistenceEntityFrameworkCoreModule))]
 public sealed class NotificationServiceModule : GranitModule, IMigratableModule<NotificationServiceDbContext>
 {
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.AddNotificationDefinitions<CatalogNotificationDefinitionProvider>();
+
+        // Email channel via SMTP — wired to the Mailpit container in AppHost for
+        // local dev. To actually deliver, opt-in by adding NotificationChannels.Email
+        // to a notification's DefaultChannels and register an IRecipientResolver.
+        context.Services.AddGranitNotificationsEmail();
+        context.Services.AddGranitNotificationsEmailSmtp();
+    }
 }

--- a/src/GranitMicroservice.NotificationService/appsettings.Development.json
+++ b/src/GranitMicroservice.NotificationService/appsettings.Development.json
@@ -8,6 +8,15 @@
   "ConnectionStrings": {
     "notification-db": "Host=localhost;Database=notification;Username=postgres;Password=postgres"
   },
+  "Notifications": {
+    "Email": {
+      "Smtp": {
+        "Host": "localhost",
+        "Port": 1025,
+        "UseSsl": false
+      }
+    }
+  },
   "Cache": {
     "Encryption": {
       "Key": "lY9eEEXC7sAYSMK+aN9EXwCBaP98nBU/0Uep2fu96o0=",

--- a/src/GranitMicroservice.NotificationService/appsettings.json
+++ b/src/GranitMicroservice.NotificationService/appsettings.json
@@ -22,5 +22,12 @@
     "Postgresql": {
       "TransportConnectionStringName": "notification-db"
     }
+  },
+  "Notifications": {
+    "Email": {
+      "Provider": "Smtp",
+      "DefaultSenderEmail": "noreply@granit-microservice.local",
+      "DefaultSenderName": "GranitMicroservice"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Adds a local SMTP sink (Mailpit) so devs scaffolding from the template can exercise email notifications end-to-end without configuring a real provider.
- Wires `Granit.Notifications.Email` + `.Smtp` in `NotificationService` with showcase-aligned config (`Notifications.Email.{Provider,DefaultSender*}` in base, `Notifications.Email.Smtp.{Host,Port,UseSsl}` in Development).
- `CatalogNotifications` stays in-app only by design — devs opt-in the Email channel via `DefaultChannels` + an `IRecipientResolver`, as documented inline.

## Test plan

- [ ] \`dotnet build GranitMicroservice.slnx\` passes
- [ ] \`dotnet run --project src/GranitMicroservice.AppHost\` brings Mailpit up (UI on http://localhost:8025, SMTP on :1025)
- [ ] \`notification-service\` resource shows healthy in the Aspire dashboard with \`mailpit\` listed under WaitFor dependencies
- [ ] After opt-in to Email channel + recipient resolver, an emitted notification lands in the Mailpit UI