### PR TITLE
fix(scalar): set AllowCredentials=true so Scalar try-it works cross-origin

### DIFF
--- a/src/GranitMicroservice.ApiGateway/appsettings.json
+++ b/src/GranitMicroservice.ApiGateway/appsettings.json
@@ -39,9 +39,6 @@
       }
     ]
   },
-  "Cors": {
-    "AllowedOrigins": []
-  },
   "ReverseProxy": {
     "Routes": {
       "catalog": {
@@ -93,6 +90,9 @@
     }
   },
   "Http": {
+    "Cors": {
+      "AllowedOrigins": []
+    },
     "ApiDocumentation": {
       "OAuth2": {
         "AuthorizationUrl": "http://localhost:8080/realms/granit/protocol/openid-connect/auth",

--- a/src/GranitMicroservice.CatalogService/appsettings.json
+++ b/src/GranitMicroservice.CatalogService/appsettings.json
@@ -42,7 +42,8 @@
   },
   "Http": {
     "Cors": {
-      "AllowedOrigins": []
+      "AllowedOrigins": [],
+      "AllowCredentials": true
     },
     "ApiDocumentation": {
       "Title": "Catalog Service API",

--- a/src/GranitMicroservice.IdentityService/appsettings.json
+++ b/src/GranitMicroservice.IdentityService/appsettings.json
@@ -38,7 +38,8 @@
   },
   "Http": {
     "Cors": {
-      "AllowedOrigins": []
+      "AllowedOrigins": [],
+      "AllowCredentials": true
     },
     "ApiDocumentation": {
       "Title": "Identity Service API",


### PR DESCRIPTION
## Summary

- Sets \`Http:Cors:AllowCredentials: true\` on IdentityService + CatalogService so Scalar's "Try it" button (which uses \`credentials: 'include'\`) no longer fails the cross-origin preflight from the gateway-hosted Scalar UI.
- Follow-up to #48 — that PR added the origins but left \`AllowCredentials\` at the default; browser then rejects the response and surfaces the misleading "No Access-Control-Allow-Origin header" error.
- Also fixes a latent bug in the gateway base \`appsettings.json\` — the \`Cors\` section was at root instead of under \`Http\`. Dev override used the correct path so dev worked, but a non-Development startup would have failed \`GranitCorsOptionsValidator\` (MinLength(1) on AllowedOrigins). Gateway intentionally keeps \`AllowCredentials\` unset because the dev override ships \`AllowedOrigins: ["*"]\` and the validator forbids that combination per the CORS spec.

## Test plan

- [ ] \`dotnet build GranitMicroservice.slnx\` passes
- [ ] Curl preflight returns the expected headers:
  \`\`\`bash
  curl -i -X OPTIONS http://localhost:5120/products \\
    -H "Origin: http://localhost:5100" \\
    -H "Access-Control-Request-Method: GET"
  # Expect: Access-Control-Allow-Origin: http://localhost:5100
  #         Access-Control-Allow-Credentials: true
  \`\`\`
- [ ] Scalar UI at http://localhost:5100/scalar — "Try it" on a Catalog or Identity endpoint completes without browser CORS errors
- [ ] Setting \`ASPNETCORE_ENVIRONMENT=Production\` for the gateway no longer crashes on \`Http:Cors\` MinLength validation