### PR TITLE
fix(template): migrate to split Granit.Http.RateLimiting package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,6 +23,7 @@
     <PackageVersion Include="Granit.Events.Wolverine" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Http.ApiDocumentation" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Http.Cors" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Http.RateLimiting" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Http.Resilience" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Identity" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Identity.EntityFrameworkCore" Version="0.1.0-dev.*" />
@@ -34,7 +35,6 @@
     <PackageVersion Include="Granit.Observability" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Persistence.EntityFrameworkCore" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Persistence.EntityFrameworkCore.Hosting" Version="0.1.0-dev.*" />
-    <PackageVersion Include="Granit.RateLimiting" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Wolverine" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Wolverine.Postgresql" Version="0.1.0-dev.*" />
   </ItemGroup>

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -66,6 +66,7 @@ Last updated: 2026-03-25
 | Granit.EventBus | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.EventBus.Wolverine | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Http.Cors | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
+| Granit.Http.RateLimiting | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Http.Resilience | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Identity | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Identity.Endpoints | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
@@ -76,7 +77,6 @@ Last updated: 2026-03-25
 | Granit.Observability | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Persistence.EntityFrameworkCore | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Persistence.EntityFrameworkCore.Hosting | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
-| Granit.RateLimiting | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Wolverine | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Wolverine.Postgresql | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | OpenTelemetry.Exporter.OpenTelemetryProtocol | 1.15.x | Copyright The OpenTelemetry Authors |

--- a/src/GranitMicroservice.CatalogService/CatalogServiceModule.cs
+++ b/src/GranitMicroservice.CatalogService/CatalogServiceModule.cs
@@ -4,7 +4,7 @@ using Granit.Persistence.EntityFrameworkCore;
 using Granit.Persistence.EntityFrameworkCore.DataSeeding;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Persistence.EntityFrameworkCore.Hosting;
-using Granit.RateLimiting;
+using Granit.Http.RateLimiting;
 using Granit.Validation;
 using Granit.Validation.Extensions;
 using GranitMicroservice.CatalogService.Persistence;
@@ -14,7 +14,7 @@ namespace GranitMicroservice.CatalogService;
 [DependsOn(
     typeof(GranitHttpApiDocumentationModule),
     typeof(GranitPersistenceEntityFrameworkCoreModule),
-    typeof(GranitRateLimitingModule),
+    typeof(GranitHttpRateLimitingModule),
     typeof(GranitValidationModule))]
 public sealed class CatalogServiceModule : GranitModule, IMigratableModule<CatalogDbContext>
 {

--- a/src/GranitMicroservice.CatalogService/Endpoints/ProductEndpoints.cs
+++ b/src/GranitMicroservice.CatalogService/Endpoints/ProductEndpoints.cs
@@ -1,5 +1,5 @@
 using Granit.Events;
-using Granit.RateLimiting.AspNetCore;
+using Granit.Http.RateLimiting.AspNetCore;
 using GranitMicroservice.CatalogService.Domain;
 using GranitMicroservice.CatalogService.Persistence;
 using GranitMicroservice.Shared.Events;

--- a/src/GranitMicroservice.CatalogService/GranitMicroservice.CatalogService.csproj
+++ b/src/GranitMicroservice.CatalogService/GranitMicroservice.CatalogService.csproj
@@ -3,8 +3,8 @@
   <ItemGroup>
     <PackageReference Include="Granit.Http.ApiDocumentation" />
     <PackageReference Include="Granit.Http.Cors" />
+    <PackageReference Include="Granit.Http.RateLimiting" />
     <PackageReference Include="Granit.Persistence.EntityFrameworkCore" />
-    <PackageReference Include="Granit.RateLimiting" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />


### PR DESCRIPTION
## Context

The Granit `RateLimiting` package was split into:

- **`Granit.RateLimiting`** — framework-pure core (counter store, quota provider, `TenantPartitionedRateLimiter`)
- **`Granit.Http.RateLimiting`** — ASP.NET Core binding (429 mapping, `GranitHttpRateLimitingModule`, and the `RequireGranitRateLimiting("policy")` endpoint filter)

The template still referenced the old `Granit.RateLimiting.AspNetCore` namespace, which no longer exists → the build broke against the latest `0.1.0-dev.*` packages.

## Changes

- `CatalogService`: reference `Granit.Http.RateLimiting`, depend on `GranitHttpRateLimitingModule`, import the new `Granit.Http.RateLimiting.AspNetCore` namespace in `ProductEndpoints`.
- Drop the now-transitive direct `Granit.RateLimiting` reference (pulled in by the Http package).
- Update `Directory.Packages.props` + `THIRD-PARTY-NOTICES.md`.

## Validation

- `dotnet build` CatalogService: ✅ 0 errors / 0 warnings
- `dotnet test` CatalogService.Tests: ✅ 14/14
- `markdownlint-cli2 THIRD-PARTY-NOTICES.md`: ✅ 0 errors

## Note

This is an independent breaking change from the latest framework wave (separate from the DualScopeStorageMode V2 adoption, which lands in a follow-up PR). Full-solution CI stays red until the DualScopeStorageMode PR also lands, because `develop`'s IdentityService is independently broken against the same package bump.