### PR TITLE
feat(template): adopt Granit DualScopeStorageMode V2 API

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,20 @@
+[extend]
+useDefault = true
+
+[allowlist]
+  description = "Allowlist for template dev-only configuration"
+
+  # Each service's appsettings.Development.json ships placeholder secrets
+  # (Cache:Encryption:Key, EmailLookupPepper, local Postgres credentials, …)
+  # meant to be overridden via Vault / environment variables outside of
+  # Development. They are committed on purpose so the scaffolded template runs
+  # out-of-the-box locally — the same convention as granit-showcase-dotnet.
+  paths = [
+    '''appsettings\.Development\.json$''',
+  ]
+
+  # Historical commit that first introduced the dev Cache:Encryption:Key
+  # (pre-allowlist). Needed because CI scans full history (--log-opts="--all").
+  commits = [
+    "be71ccc28b4fe5309ac0e83bf278777a5adcec49",
+  ]

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,6 +23,7 @@
     <PackageVersion Include="Granit.Events.Wolverine" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Http.ApiDocumentation" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Http.Cors" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Http.RateLimiting" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Http.Resilience" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Identity" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Identity.EntityFrameworkCore" Version="0.1.0-dev.*" />
@@ -34,7 +35,6 @@
     <PackageVersion Include="Granit.Observability" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Persistence.EntityFrameworkCore" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Persistence.EntityFrameworkCore.Hosting" Version="0.1.0-dev.*" />
-    <PackageVersion Include="Granit.RateLimiting" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Wolverine" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Wolverine.Postgresql" Version="0.1.0-dev.*" />
   </ItemGroup>

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -66,6 +66,7 @@ Last updated: 2026-03-25
 | Granit.EventBus | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.EventBus.Wolverine | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Http.Cors | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
+| Granit.Http.RateLimiting | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Http.Resilience | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Identity | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Identity.Endpoints | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
@@ -76,7 +77,6 @@ Last updated: 2026-03-25
 | Granit.Observability | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Persistence.EntityFrameworkCore | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Persistence.EntityFrameworkCore.Hosting | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
-| Granit.RateLimiting | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Wolverine | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Wolverine.Postgresql | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | OpenTelemetry.Exporter.OpenTelemetryProtocol | 1.15.x | Copyright The OpenTelemetry Authors |

--- a/src/GranitMicroservice.CatalogService/CatalogServiceModule.cs
+++ b/src/GranitMicroservice.CatalogService/CatalogServiceModule.cs
@@ -4,7 +4,7 @@ using Granit.Persistence.EntityFrameworkCore;
 using Granit.Persistence.EntityFrameworkCore.DataSeeding;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Persistence.EntityFrameworkCore.Hosting;
-using Granit.RateLimiting;
+using Granit.Http.RateLimiting;
 using Granit.Validation;
 using Granit.Validation.Extensions;
 using GranitMicroservice.CatalogService.Persistence;
@@ -14,7 +14,7 @@ namespace GranitMicroservice.CatalogService;
 [DependsOn(
     typeof(GranitHttpApiDocumentationModule),
     typeof(GranitPersistenceEntityFrameworkCoreModule),
-    typeof(GranitRateLimitingModule),
+    typeof(GranitHttpRateLimitingModule),
     typeof(GranitValidationModule))]
 public sealed class CatalogServiceModule : GranitModule, IMigratableModule<CatalogDbContext>
 {

--- a/src/GranitMicroservice.CatalogService/Endpoints/ProductEndpoints.cs
+++ b/src/GranitMicroservice.CatalogService/Endpoints/ProductEndpoints.cs
@@ -1,5 +1,5 @@
 using Granit.Events;
-using Granit.RateLimiting.AspNetCore;
+using Granit.Http.RateLimiting.AspNetCore;
 using GranitMicroservice.CatalogService.Domain;
 using GranitMicroservice.CatalogService.Persistence;
 using GranitMicroservice.Shared.Events;

--- a/src/GranitMicroservice.CatalogService/GranitMicroservice.CatalogService.csproj
+++ b/src/GranitMicroservice.CatalogService/GranitMicroservice.CatalogService.csproj
@@ -3,8 +3,8 @@
   <ItemGroup>
     <PackageReference Include="Granit.Http.ApiDocumentation" />
     <PackageReference Include="Granit.Http.Cors" />
+    <PackageReference Include="Granit.Http.RateLimiting" />
     <PackageReference Include="Granit.Persistence.EntityFrameworkCore" />
-    <PackageReference Include="Granit.RateLimiting" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />

--- a/src/GranitMicroservice.IdentityService/Persistence/IdentityServiceDbContext.cs
+++ b/src/GranitMicroservice.IdentityService/Persistence/IdentityServiceDbContext.cs
@@ -1,7 +1,6 @@
 using Granit.DataFiltering;
 using Granit.Identity.EntityFrameworkCore.Extensions;
-using Granit.Identity.Federated.Domain;
-using Granit.Identity.Federated.EntityFrameworkCore.DbContext;
+using Granit.Identity.Federated.EntityFrameworkCore.Extensions;
 using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
@@ -12,17 +11,19 @@ public sealed class IdentityServiceDbContext(
     DbContextOptions<IdentityServiceDbContext> options,
     ICurrentTenant currentTenant,
     IDataFilter? dataFilter = null)
-    : GranitDbContext(options, currentTenant, dataFilter), IUserCacheDbContext
+    : GranitDbContext(options, currentTenant, dataFilter)
 {
-    public DbSet<FederatedIdentity> FederatedIdentities => Set<FederatedIdentity>();
-
     protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
     {
         // Owns the migrations for both the federated identity cache
-        // (FederatedIdentity) and the canonical User aggregate. The runtime
-        // writes to the User table go through IdentityDbContext registered
-        // by AddGranitIdentityEntityFrameworkCore — both contexts map the
-        // same physical table.
+        // (identity_user_cache_entries) and the canonical User aggregate. Runtime
+        // reads/writes go through the stores' own DbContexts — the internal
+        // IdentityFederatedHostDbContext and IdentityHostDbContext, registered by
+        // AddGranitIdentityFederatedEntityFrameworkCore and
+        // AddGranitIdentityEntityFrameworkCore respectively — which map the same
+        // physical tables. Calling the Configure*Module() helpers here keeps schema
+        // ownership on this single host-migrated context
+        // (see IdentityServiceModule : IMigratableModule).
         modelBuilder.ConfigureIdentityModule();
         modelBuilder.ConfigureGranitIdentityModule();
     }

--- a/src/GranitMicroservice.IdentityService/Program.cs
+++ b/src/GranitMicroservice.IdentityService/Program.cs
@@ -11,6 +11,7 @@ using Granit.Identity.Federated.EntityFrameworkCore.Extensions;
 using Granit.Identity.Federated.Keycloak.Extensions;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Persistence.EntityFrameworkCore.Hosting.Extensions;
+using Granit.Persistence.MultiTenancy;
 using GranitMicroservice.IdentityService;
 using Microsoft.EntityFrameworkCore;
 using GranitMicroservice.IdentityService.Persistence;
@@ -56,15 +57,41 @@ builder.Services.AddGranitDbContext<IdentityServiceDbContext>(options =>
 // Two registrations, both required:
 //   1. Federated cache (Granit.Identity.Federated.EntityFrameworkCore) — replaces
 //      NullUserLookupService with CachedUserLookupService and wires the federated
-//      identity cache against IdentityServiceDbContext.
+//      identity cache against its own IdentityFederatedHostDbContext. Since the
+//      Granit DualScopeStorageMode V2 API (Epic #2382) this is registered on the
+//      IHostApplicationBuilder via an options object: StorageMode selects the
+//      physical layout, Configure supplies the EF Core provider + connection.
 //   2. Canonical user directory (Granit.Identity.EntityFrameworkCore) — registers
-//      the isolated IdentityDbContext + IUserDirectoryWriter required by
+//      the IdentityHostDbContext + IUserDirectoryWriter required by
 //      CachedUserLookupService to materialise the User aggregate on cache miss.
-//      Migrations for the User table live on IdentityServiceDbContext (see
-//      ConfigureGranitIdentityModule in OnGranitModelCreating).
-builder.Services.AddGranitIdentityEntityFrameworkCore<IdentityServiceDbContext>();
-builder.Services.AddGranitIdentityEntityFrameworkCore(options =>
-    options.UseNpgsql(builder.Configuration.GetConnectionString("identity-db")));
+//      Migrations for both tables live on IdentityServiceDbContext (see
+//      ConfigureIdentityModule + ConfigureGranitIdentityModule in OnGranitModelCreating).
+// Both adopt the Granit DualScopeStorageMode V2 API: registered on the
+// IHostApplicationBuilder via an options object whose StorageMode selects the
+// physical layout and whose Configure supplies the EF Core provider + connection.
+builder.AddGranitIdentityFederatedEntityFrameworkCore(opts =>
+{
+    // Shared (default): a single host table holds every federated identity; tenant
+    // rows carry a TenantId filtered by a row-level query filter. Behavioural
+    // equivalent of the pre-V2 registration.
+    opts.StorageMode = DualScopeStorageMode.Shared;
+    opts.Configure = db => db.UseNpgsql(builder.Configuration.GetConnectionString("identity-db"));
+
+    // Pour activer l'isolation physique par tenant (RGPD Art. 17, ISO 27001 A.8.12):
+    // opts.StorageMode = DualScopeStorageMode.Segregated;
+    // opts.ConfigureHost = db => db.UseNpgsql(hostConnString);
+    // opts.ConfigureSchemaPerTenant = db => db.UseNpgsql(baseConnString);
+});
+builder.AddGranitIdentityEntityFrameworkCore(opts =>
+{
+    opts.StorageMode = DualScopeStorageMode.Shared;
+    opts.Configure = db => db.UseNpgsql(builder.Configuration.GetConnectionString("identity-db"));
+
+    // Pour activer l'isolation physique par tenant (RGPD Art. 17, ISO 27001 A.8.12):
+    // opts.StorageMode = DualScopeStorageMode.Segregated;
+    // opts.ConfigureHost = db => db.UseNpgsql(hostConnString);
+    // opts.ConfigureSchemaPerTenant = db => db.UseNpgsql(baseConnString);
+});
 
 // ── Step 5 · CORS ─────────────────────────────────────────────────────────────
 // Strict BFF in production: the SPA only talks to the gateway, never to this


### PR DESCRIPTION
## Context

Granit shipped its V2 wave (Epic granit-fx/granit-dotnet#2382), which reworked the EF Core registration API for the dual-scope identity modules:

- `AddGranitIdentityEntityFrameworkCore` / `AddGranitIdentityFederatedEntityFrameworkCore` moved from `(IServiceCollection, Action<DbContextOptionsBuilder>)` → `(IHostApplicationBuilder, Action<{X}EntityFrameworkCoreOptions>)`.
- The legacy `IUserCacheDbContext` interface and the generic `AddGranitIdentityEntityFrameworkCore<TContext>()` federated overload were removed.
- `StorageMode` (`DualScopeStorageMode.Shared` | `Segregated`) now selects the physical layout.

## Why this PR bundles three commits

The same `0.1.0-dev.*` package bump broke the template on **two independent build fronts** that cannot be split into separately-green PRs (each project needs its own fix for the solution to compile): IdentityService needs the DualScope migration, CatalogService needs the RateLimiting package split. A third CI job (gitleaks) was already failing on `develop`. So this PR lands them together; it **supersedes #53** (whose RateLimiting commit is the first commit here).

### 1. `feat`: DualScopeStorageMode V2 adoption
- `IdentityService/Program.cs`: both registrations now use the V2 options API on `builder` in **Shared** mode (behavioural equivalent of the pre-V2 wiring):
  ```csharp
  builder.AddGranitIdentityFederatedEntityFrameworkCore(opts =>
  {
      opts.StorageMode = DualScopeStorageMode.Shared;
      opts.Configure = db => db.UseNpgsql(builder.Configuration.GetConnectionString("identity-db"));
  });
  ```
- Illustrative comment (per Epic #2382) showing how to opt into `Segregated` per-tenant isolation (GDPR Art. 17 / ISO 27001 A.8.12).
- `IdentityServiceDbContext`: dropped the removed `IUserCacheDbContext` interface + `FederatedIdentity` `DbSet`; schema ownership stays on this host-migrated context via the now-public `ConfigureIdentityModule()` + `ConfigureGranitIdentityModule()` helpers.

### 2. `fix`: Granit.Http.RateLimiting package split
- The RateLimiting package was split into core (`Granit.RateLimiting`) + ASP.NET Core binding (`Granit.Http.RateLimiting`). CatalogService now references the Http package, depends on `GranitHttpRateLimitingModule`, and imports `Granit.Http.RateLimiting.AspNetCore`. `Directory.Packages.props` + `THIRD-PARTY-NOTICES.md` updated.

### 3. `ci`: gitleaks allowlist for dev-only appsettings
- CI scans full history; the dev-only `Cache:Encryption:Key` in the per-service `appsettings.Development.json` was flagged. Added a `.gitleaks.toml` allowlist (path + introducing commit), mirroring the granit-showcase-dotnet convention (these files stay committed so the scaffold runs out-of-the-box locally).

## Validation

- `dotnet build GranitMicroservice.slnx`: ✅ 0 errors / 0 warnings
- `dotnet test GranitMicroservice.slnx`: ✅ all green (Catalog 14 + Catalog.Integration 6 + Identity 2 + Notification 5 + AppHost 8)
- `dotnet ef migrations has-pending-model-changes` (IdentityServiceDbContext): ✅ no model changes → behavioural equivalence, no migration drift
- `gitleaks detect --source . --log-opts="--all"`: ✅ no leaks found

## Upstream framework fix prerequisite

This adoption surfaced a V2 regression in `Granit.Identity.Federated.EntityFrameworkCore`: the model-config helper `UserCacheModelBuilderExtensions` was `internal`, so a host could not own the federated cache table migration (its Webhooks sibling is `public`). Fixed upstream in granit-dotnet (now `public` in `…EntityFrameworkCore.Extensions`), packages rebuilt to `0.1.0-dev.3181`.