### PR TITLE
fix(notifications): register durable EF Core notification stores

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,6 +34,7 @@
     <PackageVersion Include="Granit.Notifications.Email" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Notifications.Email.Smtp" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Notifications.EntityFrameworkCore" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Notifications.MobilePush" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Observability" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Persistence.EntityFrameworkCore" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Persistence.EntityFrameworkCore.Hosting" Version="0.1.0-dev.*" />

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -74,6 +74,7 @@ Last updated: 2026-03-25
 | Granit.Identity.Keycloak | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Notifications | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Notifications.EntityFrameworkCore | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
+| Granit.Notifications.MobilePush | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Observability | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Persistence.EntityFrameworkCore | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Persistence.EntityFrameworkCore.Hosting | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |

--- a/src/GranitMicroservice.NotificationService/GranitMicroservice.NotificationService.csproj
+++ b/src/GranitMicroservice.NotificationService/GranitMicroservice.NotificationService.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Granit.Notifications.Email" />
     <PackageReference Include="Granit.Notifications.Email.Smtp" />
     <PackageReference Include="Granit.Notifications.EntityFrameworkCore" />
+    <PackageReference Include="Granit.Notifications.MobilePush" />
     <PackageReference Include="Granit.Persistence.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />

--- a/src/GranitMicroservice.NotificationService/NotificationServiceModule.cs
+++ b/src/GranitMicroservice.NotificationService/NotificationServiceModule.cs
@@ -1,19 +1,26 @@
 using Granit.Modularity;
 using Granit.Notifications;
 using Granit.Notifications.Abstractions;
+using Granit.Notifications.EntityFrameworkCore;
+using Granit.Notifications.EntityFrameworkCore.Extensions;
 using Granit.Notifications.Email.Extensions;
 using Granit.Notifications.Email.Smtp.Extensions;
 using Granit.Notifications.Extensions;
+using Granit.Notifications.MobilePush.Extensions;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.Persistence.EntityFrameworkCore.Hosting;
+using Granit.Persistence.MultiTenancy;
 using GranitMicroservice.NotificationService.Notifications;
 using GranitMicroservice.NotificationService.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace GranitMicroservice.NotificationService;
 
 [DependsOn(
     typeof(GranitNotificationsModule),
+    typeof(GranitNotificationsEntityFrameworkCoreModule),
     typeof(GranitPersistenceEntityFrameworkCoreModule))]
 public sealed class NotificationServiceModule : GranitModule, IMigratableModule<NotificationServiceDbContext>
 {
@@ -27,6 +34,29 @@ public sealed class NotificationServiceModule : GranitModule, IMigratableModule<
         // by default).
         context.Services.AddGranitNotificationsEmail();
         context.Services.AddGranitNotificationsEmailSmtp();
+
+        // Durable EF Core stores for user notifications + preferences (replaces the
+        // default in-memory stores). Shared mode keeps every tenant's rows in one host
+        // table with a row-level filter — the behavioural default. Migrations for the
+        // table are owned by NotificationServiceDbContext via ConfigureNotificationsModule.
+        context.Builder.AddGranitNotificationsEntityFrameworkCore(opts =>
+        {
+            opts.StorageMode = DualScopeStorageMode.Shared;
+            opts.Configure = db => db.UseNpgsql(
+                context.Builder.Configuration.GetConnectionString("notification-db"));
+
+            // Pour activer l'isolation physique par tenant (RGPD Art. 17, ISO 27001 A.8.12):
+            // opts.StorageMode = DualScopeStorageMode.Segregated;
+            // opts.ConfigureHost = db => db.UseNpgsql(hostConnString);
+            // opts.ConfigureSchemaPerTenant = db => db.UseNpgsql(baseConnString);
+        });
+
+        // AddGranitNotificationsEntityFrameworkCore unconditionally registers
+        // EfCoreMobilePushTokenStore, which depends on IMobilePushTokenHasher — provided
+        // by AddGranitNotificationsMobilePush (HMAC over a configured device-token pepper).
+        // The package's in-memory token store is replaced by the EF Core one above; this
+        // call only supplies the hasher + options binding, no mobile-push channel is used.
+        context.Services.AddGranitNotificationsMobilePush();
 
         // Every Granit notification channel resolves recipient contact info through an
         // IRecipientResolver. Granit ships no default — recipient lookup is

--- a/src/GranitMicroservice.NotificationService/Notifications/NotificationRecipientResolver.cs
+++ b/src/GranitMicroservice.NotificationService/Notifications/NotificationRecipientResolver.cs
@@ -9,11 +9,22 @@ namespace GranitMicroservice.NotificationService.Notifications;
 /// Granit ships no default because recipient lookup is application-specific.
 /// </summary>
 /// <remarks>
-/// This template implementation is a placeholder. A real notification service resolves
-/// contact details from its own user read-model — synchronized from the identity service
+/// <para>
+/// This template runs NotificationService as a <b>separate</b> service from IdentityService,
+/// so recipient lookup crosses a service boundary: a real implementation resolves contact
+/// details from this service's own user read-model — synchronized from the identity service
 /// via integration events — or from the originating notification payload. Replace the body
-/// with a lookup against your user directory and return <c>null</c> for unknown users so the
-/// channel can skip them.
+/// with that lookup and return <c>null</c> for unknown users so the channel can skip them.
+/// This placeholder keeps the distributed pattern intact.
+/// </para>
+/// <para>
+/// For a monolith / co-located deployment where <c>Granit.Identity</c> (and
+/// <c>IIdentityUserReader</c>) runs in the SAME process as the notification pipeline, drop
+/// this class and use the ready-made resolver from <c>Granit.Identity.Notifications</c>
+/// instead: add the package reference and call <c>services.AddGranitIdentityRecipientResolver()</c>
+/// (see granit-fx/granit-dotnet#2444). It does not fit here because this service has no
+/// in-process identity store.
+/// </para>
 /// </remarks>
 internal sealed class NotificationRecipientResolver : IRecipientResolver
 {

--- a/src/GranitMicroservice.NotificationService/appsettings.Development.json
+++ b/src/GranitMicroservice.NotificationService/appsettings.Development.json
@@ -15,6 +15,11 @@
         "Port": 1025,
         "UseSsl": false
       }
+    },
+    "MobilePush": {
+      "TokenHasher": {
+        "DeviceTokenLookupPepper": "b7d2f4a9c1e8536074a2b9d4c6e1f8035927a4b1c8d3e6f90a2b5c8d1e4f7a30"
+      }
     }
   },
   "Cache": {


### PR DESCRIPTION
## Problem

`NotificationService` folds `ConfigureNotificationsModule()` into `NotificationServiceDbContext` (so the `notifications_user_notifications` table is created + migrated) but never called `AddGranitNotificationsEntityFrameworkCore`. As a result the notification pipeline used the framework's **in-memory / no-op stores** — the table was created but never written to. `granit-showcase-dotnet` wires both (fold + `AddGranitNotificationsEntityFrameworkCore`).

## Changes

### 1. Register the EF Core stores (Shared mode)
`AddGranitNotificationsEntityFrameworkCore` on the module's `context.Builder`, replacing the in-memory stores with `EfCoreUserNotificationStore` / preference stores. Includes the illustrative `Segregated` comment (Epic #2382). The fold in `NotificationServiceDbContext` keeps owning the migration.

### 2. Mobile-push hasher (cascade)
`AddGranitNotificationsEntityFrameworkCore` unconditionally registers `EfCoreMobilePushTokenStore`, which depends on `IMobilePushTokenHasher`. Per the showcase, this is satisfied by `AddGranitNotificationsMobilePush()` (HMAC over a configured device-token pepper). Added the package + a dev `Notifications:MobilePush:TokenHasher:DeviceTokenLookupPepper` (allowlisted by the existing `.gitleaks.toml`). No mobile-push channel is actually used; `MobilePushToken` is already in the folded snapshot, so **no new migration** is needed.

### 3. Recipient resolver — keep custom, document the in-process alternative (ref #2444)
granit-dotnet#2444 ships a default `IRecipientResolver` over the in-process `IIdentityUserReader`. It does **not** fit here: `NotificationService` is a **separate** service with no in-process `Granit.Identity`, so recipient resolution crosses a service boundary. The custom `NotificationRecipientResolver` is kept (preserving the distributed pattern) and its doc-comment now points to `Granit.Identity.Notifications` (`AddGranitIdentityRecipientResolver()`) as the monolith/co-located alternative.

## Validation (local, pinned `0.1.0-dev.3188`)

- `dotnet build`: ✅ 0 errors / 0 warnings
- `dotnet test` NotificationService.Tests: ✅ 5/5
- **Boot**: passes DI validation (Wolverine startup reached) — no unresolved services, no pepper error
- `has-pending-model-changes`: ✅ no changes
- `dotnet format --verify-no-changes`: ✅ clean (changed files)

## ⚠️ CI / feed note

The GitLab dev feed currently has an **incoherent partial publish** (`Granit.Http.Cors` etc. at `0.1.0-dev.3190` while core `Granit` / `Persistence` / `Validation` / `Localization` are only at `3188`), so floating `0.1.0-dev.*` restore fails (`NU1102`/`NU1107`) — same class of issue as the earlier 3186/3184 skew. CI will stay red until a **coherent set** (all packages at one build, incl. `Granit.Notifications.MobilePush`) is republished. The code is verified against the coherent `3188` set.