### PR TITLE
feat(identity): persist the audit trail via EF Core

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
   <ItemGroup Label="Granit">
     <PackageVersion Include="Granit" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Bundle.Essentials" Version="0.1.0-dev.*" />
+    <PackageVersion Include="Granit.Auditing.EntityFrameworkCore" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Authentication.JwtBearer" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Bff" Version="0.1.0-dev.*" />
     <PackageVersion Include="Granit.Bff.Endpoints" Version="0.1.0-dev.*" />

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -13,7 +13,7 @@ Last updated: 2026-03-25
 | License      | Package count |
 | ------------ | ------------- |
 | MIT          | 19            |
-| Apache-2.0   | 34            |
+| Apache-2.0   | 35            |
 | BSD-3-Clause | 2             |
 | PostgreSQL   | 1             |
 
@@ -55,6 +55,7 @@ Last updated: 2026-03-25
 | FluentValidation | 12.x | Copyright (c) Jeremy Skinner, .NET Foundation 2008-2025 |
 | FluentValidation.DependencyInjectionExtensions | 12.x | Copyright (c) Jeremy Skinner, .NET Foundation 2008-2025 |
 | Granit | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
+| Granit.Auditing.EntityFrameworkCore | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Authentication.JwtBearer | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Authentication.JwtBearer.Keycloak | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |
 | Granit.Authorization | 0.1.x (prerelease) | (c) 2025-2026 Digital Dynamics |

--- a/src/GranitMicroservice.IdentityService/GranitMicroservice.IdentityService.csproj
+++ b/src/GranitMicroservice.IdentityService/GranitMicroservice.IdentityService.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Granit.Auditing.EntityFrameworkCore" />
     <PackageReference Include="Granit.Authentication.JwtBearer.Keycloak" />
     <PackageReference Include="Granit.Authorization" />
     <PackageReference Include="Granit.Http.ApiDocumentation" />

--- a/src/GranitMicroservice.IdentityService/IdentityServiceModule.cs
+++ b/src/GranitMicroservice.IdentityService/IdentityServiceModule.cs
@@ -1,3 +1,4 @@
+using Granit.Auditing.EntityFrameworkCore;
 using Granit.Authentication.JwtBearer;
 using Granit.Authentication.JwtBearer.Keycloak;
 using Granit.Authorization;
@@ -15,6 +16,7 @@ using GranitMicroservice.IdentityService.Persistence;
 namespace GranitMicroservice.IdentityService;
 
 [DependsOn(
+    typeof(GranitAuditingEntityFrameworkCoreModule),
     typeof(GranitAuthenticationJwtBearerKeycloakModule),
     typeof(GranitAuthorizationModule),
     typeof(GranitHttpApiDocumentationModule),

--- a/src/GranitMicroservice.IdentityService/Persistence/IdentityServiceDbContext.cs
+++ b/src/GranitMicroservice.IdentityService/Persistence/IdentityServiceDbContext.cs
@@ -1,3 +1,4 @@
+using Granit.Auditing.EntityFrameworkCore.Extensions;
 using Granit.DataFiltering;
 using Granit.Identity.EntityFrameworkCore.Extensions;
 using Granit.Identity.Federated.EntityFrameworkCore.Extensions;
@@ -15,16 +16,17 @@ public sealed class IdentityServiceDbContext(
 {
     protected override void OnGranitModelCreating(ModelBuilder modelBuilder)
     {
-        // Owns the migrations for both the federated identity cache
-        // (identity_user_cache_entries) and the canonical User aggregate. Runtime
-        // reads/writes go through the stores' own DbContexts — the internal
-        // IdentityFederatedHostDbContext and IdentityHostDbContext, registered by
-        // AddGranitIdentityFederatedEntityFrameworkCore and
-        // AddGranitIdentityEntityFrameworkCore respectively — which map the same
-        // physical tables. Calling the Configure*Module() helpers here keeps schema
-        // ownership on this single host-migrated context
-        // (see IdentityServiceModule : IMigratableModule).
+        // Owns the migrations for the federated identity cache
+        // (identity_user_cache_entries), the canonical User aggregate, and the audit
+        // trail. Runtime reads/writes go through the stores' own DbContexts — the
+        // internal IdentityFederatedHostDbContext, IdentityHostDbContext and
+        // AuditingHostDbContext, registered by AddGranitIdentityFederatedEntityFrameworkCore,
+        // AddGranitIdentityEntityFrameworkCore and AddGranitAuditingEntityFrameworkCore
+        // respectively — which map the same physical tables. Calling the
+        // Configure*Module() helpers here keeps schema ownership on this single
+        // host-migrated context (see IdentityServiceModule : IMigratableModule).
         modelBuilder.ConfigureIdentityModule();
         modelBuilder.ConfigureGranitIdentityModule();
+        modelBuilder.ConfigureAuditingModule();
     }
 }

--- a/src/GranitMicroservice.IdentityService/Persistence/Migrations/20260529142821_AddAuditTrail.Designer.cs
+++ b/src/GranitMicroservice.IdentityService/Persistence/Migrations/20260529142821_AddAuditTrail.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GranitMicroservice.IdentityService.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GranitMicroservice.IdentityService.Persistence.Migrations
 {
     [DbContext(typeof(IdentityServiceDbContext))]
-    partial class IdentityServiceDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260529142821_AddAuditTrail")]
+    partial class AddAuditTrail
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GranitMicroservice.IdentityService/Persistence/Migrations/20260529142821_AddAuditTrail.cs
+++ b/src/GranitMicroservice.IdentityService/Persistence/Migrations/20260529142821_AddAuditTrail.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GranitMicroservice.IdentityService.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAuditTrail : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "audit_log_log_entries",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Timestamp = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UserId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    UserName = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    Category = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    IpAddress = table.Column<string>(type: "character varying(45)", maxLength: 45, nullable: true),
+                    UserAgent = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: true),
+                    CorrelationId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_audit_log_log_entries", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "audit_log_entity_changes",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AuditLogEntryId = table.Column<Guid>(type: "uuid", nullable: false),
+                    EntityType = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    EntityId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    ChangeType = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_audit_log_entity_changes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_audit_log_entity_changes_audit_log_log_entries_AuditLogEntr~",
+                        column: x => x.AuditLogEntryId,
+                        principalTable: "audit_log_log_entries",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "audit_log_property_changes",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AuditEntityChangeId = table.Column<Guid>(type: "uuid", nullable: false),
+                    PropertyName = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    OriginalValue = table.Column<string>(type: "text", nullable: true),
+                    NewValue = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_audit_log_property_changes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_audit_log_property_changes_audit_log_entity_changes_AuditEn~",
+                        column: x => x.AuditEntityChangeId,
+                        principalTable: "audit_log_entity_changes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_audit_log_entity_changes_AuditLogEntryId",
+                table: "audit_log_entity_changes",
+                column: "AuditLogEntryId");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_audit_log_entity_changes_type_id",
+                table: "audit_log_entity_changes",
+                columns: new[] { "EntityType", "EntityId", "AuditLogEntryId" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_audit_log_log_entries_tenant_timestamp",
+                table: "audit_log_log_entries",
+                columns: new[] { "TenantId", "Timestamp" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_audit_log_log_entries_timestamp",
+                table: "audit_log_log_entries",
+                column: "Timestamp");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_audit_log_log_entries_user_timestamp",
+                table: "audit_log_log_entries",
+                columns: new[] { "UserId", "Timestamp" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_audit_log_property_changes_AuditEntityChangeId",
+                table: "audit_log_property_changes",
+                column: "AuditEntityChangeId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "audit_log_property_changes");
+
+            migrationBuilder.DropTable(
+                name: "audit_log_entity_changes");
+
+            migrationBuilder.DropTable(
+                name: "audit_log_log_entries");
+        }
+    }
+}

--- a/src/GranitMicroservice.IdentityService/Program.cs
+++ b/src/GranitMicroservice.IdentityService/Program.cs
@@ -1,3 +1,4 @@
+using Granit.Auditing.EntityFrameworkCore.Extensions;
 using Granit.Caching.StackExchangeRedis.Extensions;
 using Granit.Extensions;
 using Granit.Diagnostics.Extensions;
@@ -83,6 +84,24 @@ builder.AddGranitIdentityFederatedEntityFrameworkCore(opts =>
     // opts.ConfigureSchemaPerTenant = db => db.UseNpgsql(baseConnString);
 });
 builder.AddGranitIdentityEntityFrameworkCore(opts =>
+{
+    opts.StorageMode = DualScopeStorageMode.Shared;
+    opts.Configure = db => db.UseNpgsql(builder.Configuration.GetConnectionString("identity-db"));
+
+    // Pour activer l'isolation physique par tenant (RGPD Art. 17, ISO 27001 A.8.12):
+    // opts.StorageMode = DualScopeStorageMode.Segregated;
+    // opts.ConfigureHost = db => db.UseNpgsql(hostConnString);
+    // opts.ConfigureSchemaPerTenant = db => db.UseNpgsql(baseConnString);
+});
+
+// ── Step 4b · Audit trail EF Core store ───────────────────────────────────────
+// IdentityServiceModule pulls GranitAuditingModule transitively (via
+// GranitIdentityModule), which runs an AuditingCleanupWorker and emits an audit
+// trail for identity operations. AddGranitAuditingEntityFrameworkCore swaps the
+// default no-op stores for durable EF Core ones (writer/reader/cleaner). Shared
+// mode keeps the trail in the identity database; migrations for the audit tables
+// are owned by IdentityServiceDbContext via ConfigureAuditingModule.
+builder.AddGranitAuditingEntityFrameworkCore(opts =>
 {
     opts.StorageMode = DualScopeStorageMode.Shared;
     opts.Configure = db => db.UseNpgsql(builder.Configuration.GetConnectionString("identity-db"));


### PR DESCRIPTION
## Context

`IdentityService` pulls `GranitAuditingModule` transitively (via `GranitIdentityModule`), which runs an `AuditingCleanupWorker` and emits an audit trail for identity operations. But no EF Core audit store was wired, so the default no-op stores silently dropped every audit write. `granit-showcase-dotnet` wires the trail via `AddGranitAuditingEntityFrameworkCore` + a `ConfigureAuditingModule()` fold.

Per the spec decision, the trail is persisted **in the identity database** (no new database). The ApiGateway keeps its `NullAuditingCleaner` (it has no DB).

## Changes

- **`Program.cs`** — `AddGranitAuditingEntityFrameworkCore` (V2 options API, `DualScopeStorageMode.Shared`, `Configure = identity-db`) + the illustrative `Segregated` comment (Epic #2382).
- **`IdentityServiceModule`** — `DependsOn(typeof(GranitAuditingEntityFrameworkCoreModule))`.
- **`IdentityServiceDbContext`** — fold `ConfigureAuditingModule()` so this single host-migrated context owns the audit tables (alongside the identity-cache + canonical-User folds).
- **`AddAuditTrail` migration** — creates `audit_log_log_entries`, `audit_log_entity_changes`, `audit_log_property_changes` (pure `CREATE TABLE`, no data loss).
- `Directory.Packages.props` + `THIRD-PARTY-NOTICES.md` updated.

## Note on Settings

The spec also flagged Settings as "mandatory", but the full transitive module closure of the template (45 modules) contains **no** `GranitSettingsModule` — it is only pulled by Identity.Local / Privacy / AI / OpenIddict.BackgroundJobs / Settings.Endpoints / Auditing.ConfigurationChanges, none of which the template uses (it runs federated/Keycloak identity). Per guidance ("si pas utile ne le met pas"), Settings is **not** added.

## Validation (local, pinned `0.1.0-dev.3188`)

- `dotnet build`: ✅ 0 errors / 0 warnings
- `dotnet test` IdentityService.Tests: ✅ 2/2
- **Boot**: passes DI validation (Wolverine startup reached) — EF audit writer/reader/cleaner resolve
- `has-pending-model-changes`: ✅ no changes
- `dotnet format --verify-no-changes`: ✅ clean (changed files)

## ⚠️ CI / feed note

The GitLab dev feed currently has an **incoherent partial publish** (`3190` for some packages, core `Granit` still at `3188`), so floating `0.1.0-dev.*` restore fails (`NU1102`/`NU1107`) — same recurring skew affecting #56. CI will stay red until a **coherent set** is republished. Code verified against the coherent `3188` set.