### PR TITLE
refactor: align EF Core registrations with granit-dotnet post-revert API

### DIFF
--- a/src/GranitMicroservice.IdentityService/Persistence/IdentityServiceDbContext.cs
+++ b/src/GranitMicroservice.IdentityService/Persistence/IdentityServiceDbContext.cs
@@ -18,13 +18,11 @@ public sealed class IdentityServiceDbContext(
     {
         // Owns the migrations for the federated identity cache
         // (identity_user_cache_entries), the canonical User aggregate, and the audit
-        // trail. Runtime reads/writes go through the stores' own DbContexts — the
-        // internal IdentityFederatedHostDbContext, IdentityHostDbContext and
-        // AuditingHostDbContext, registered by AddGranitIdentityFederatedEntityFrameworkCore,
-        // AddGranitIdentityEntityFrameworkCore and AddGranitAuditingEntityFrameworkCore
-        // respectively — which map the same physical tables. Calling the
-        // Configure*Module() helpers here keeps schema ownership on this single
-        // host-migrated context (see IdentityServiceModule : IMigratableModule).
+        // trail. Runtime reads/writes go through the internal DbContexts registered by
+        // AddGranitIdentityFederatedEntityFrameworkCore, AddGranitIdentityEntityFrameworkCore,
+        // and AddGranitAuditingEntityFrameworkCore respectively — which map the same
+        // physical tables. Calling the Configure*Module() helpers here keeps schema
+        // ownership on this single migrated context (see IdentityServiceModule : IMigratableModule).
         modelBuilder.ConfigureIdentityModule();
         modelBuilder.ConfigureGranitIdentityModule();
         modelBuilder.ConfigureAuditingModule();

--- a/src/GranitMicroservice.IdentityService/Program.cs
+++ b/src/GranitMicroservice.IdentityService/Program.cs
@@ -12,7 +12,6 @@ using Granit.Identity.Federated.EntityFrameworkCore.Extensions;
 using Granit.Identity.Federated.Keycloak.Extensions;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Persistence.EntityFrameworkCore.Hosting.Extensions;
-using Granit.Persistence.MultiTenancy;
 using GranitMicroservice.IdentityService;
 using Microsoft.EntityFrameworkCore;
 using GranitMicroservice.IdentityService.Persistence;
@@ -54,63 +53,30 @@ await builder.AddGranitAsync(granit => granit
 builder.Services.AddGranitDbContext<IdentityServiceDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("identity-db")));
 
-// ── Step 4 · Granit Identity EF Core store ───────────────────────────────────
-// Two registrations, both required:
-//   1. Federated cache (Granit.Identity.Federated.EntityFrameworkCore) — replaces
-//      NullUserLookupService with CachedUserLookupService and wires the federated
-//      identity cache against its own IdentityFederatedHostDbContext. Since the
-//      Granit DualScopeStorageMode V2 API (Epic #2382) this is registered on the
-//      IHostApplicationBuilder via an options object: StorageMode selects the
-//      physical layout, Configure supplies the EF Core provider + connection.
+// ── Step 4 · Granit Identity EF Core stores ──────────────────────────────────
+// Two registrations required:
+//   1. Federated identity cache (Granit.Identity.Federated.EntityFrameworkCore) —
+//      swaps NullUserLookupService for CachedUserLookupService; tenant rows carry a
+//      TenantId filtered by a row-level query filter on the internal DbContext.
 //   2. Canonical user directory (Granit.Identity.EntityFrameworkCore) — registers
-//      the IdentityHostDbContext + IUserDirectoryWriter required by
-//      CachedUserLookupService to materialise the User aggregate on cache miss.
-//      Migrations for both tables live on IdentityServiceDbContext (see
-//      ConfigureIdentityModule + ConfigureGranitIdentityModule in OnGranitModelCreating).
-// Both adopt the Granit DualScopeStorageMode V2 API: registered on the
-// IHostApplicationBuilder via an options object whose StorageMode selects the
-// physical layout and whose Configure supplies the EF Core provider + connection.
+//      IUserDirectoryWriter used by CachedUserLookupService to materialise the User
+//      aggregate on cache miss.
+// Migrations for both tables live on IdentityServiceDbContext (see
+// ConfigureIdentityModule + ConfigureGranitIdentityModule in OnGranitModelCreating).
 builder.AddGranitIdentityFederatedEntityFrameworkCore(opts =>
-{
-    // Shared (default): a single host table holds every federated identity; tenant
-    // rows carry a TenantId filtered by a row-level query filter. Behavioural
-    // equivalent of the pre-V2 registration.
-    opts.StorageMode = DualScopeStorageMode.Shared;
-    opts.Configure = db => db.UseNpgsql(builder.Configuration.GetConnectionString("identity-db"));
-
-    // Pour activer l'isolation physique par tenant (RGPD Art. 17, ISO 27001 A.8.12):
-    // opts.StorageMode = DualScopeStorageMode.Segregated;
-    // opts.ConfigureHost = db => db.UseNpgsql(hostConnString);
-    // opts.ConfigureSchemaPerTenant = db => db.UseNpgsql(baseConnString);
-});
-builder.AddGranitIdentityEntityFrameworkCore(opts =>
-{
-    opts.StorageMode = DualScopeStorageMode.Shared;
-    opts.Configure = db => db.UseNpgsql(builder.Configuration.GetConnectionString("identity-db"));
-
-    // Pour activer l'isolation physique par tenant (RGPD Art. 17, ISO 27001 A.8.12):
-    // opts.StorageMode = DualScopeStorageMode.Segregated;
-    // opts.ConfigureHost = db => db.UseNpgsql(hostConnString);
-    // opts.ConfigureSchemaPerTenant = db => db.UseNpgsql(baseConnString);
-});
+    opts.UseNpgsql(builder.Configuration.GetConnectionString("identity-db")));
+builder.Services.AddGranitIdentityEntityFrameworkCore(opts =>
+    opts.UseNpgsql(builder.Configuration.GetConnectionString("identity-db")));
 
 // ── Step 4b · Audit trail EF Core store ───────────────────────────────────────
 // IdentityServiceModule pulls GranitAuditingModule transitively (via
 // GranitIdentityModule), which runs an AuditingCleanupWorker and emits an audit
 // trail for identity operations. AddGranitAuditingEntityFrameworkCore swaps the
-// default no-op stores for durable EF Core ones (writer/reader/cleaner). Shared
-// mode keeps the trail in the identity database; migrations for the audit tables
-// are owned by IdentityServiceDbContext via ConfigureAuditingModule.
+// default no-op stores for durable EF Core ones (writer/reader/cleaner). Tenant
+// rows carry a TenantId filtered by a row-level query filter; migrations for the
+// audit tables are owned by IdentityServiceDbContext via ConfigureAuditingModule.
 builder.AddGranitAuditingEntityFrameworkCore(opts =>
-{
-    opts.StorageMode = DualScopeStorageMode.Shared;
-    opts.Configure = db => db.UseNpgsql(builder.Configuration.GetConnectionString("identity-db"));
-
-    // Pour activer l'isolation physique par tenant (RGPD Art. 17, ISO 27001 A.8.12):
-    // opts.StorageMode = DualScopeStorageMode.Segregated;
-    // opts.ConfigureHost = db => db.UseNpgsql(hostConnString);
-    // opts.ConfigureSchemaPerTenant = db => db.UseNpgsql(baseConnString);
-});
+    opts.UseNpgsql(builder.Configuration.GetConnectionString("identity-db")));
 
 // ── Step 5 · CORS ─────────────────────────────────────────────────────────────
 // Strict BFF in production: the SPA only talks to the gateway, never to this

--- a/src/GranitMicroservice.NotificationService/NotificationServiceModule.cs
+++ b/src/GranitMicroservice.NotificationService/NotificationServiceModule.cs
@@ -9,7 +9,6 @@ using Granit.Notifications.Extensions;
 using Granit.Notifications.MobilePush.Extensions;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.Persistence.EntityFrameworkCore.Hosting;
-using Granit.Persistence.MultiTenancy;
 using GranitMicroservice.NotificationService.Notifications;
 using GranitMicroservice.NotificationService.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -36,20 +35,11 @@ public sealed class NotificationServiceModule : GranitModule, IMigratableModule<
         context.Services.AddGranitNotificationsEmailSmtp();
 
         // Durable EF Core stores for user notifications + preferences (replaces the
-        // default in-memory stores). Shared mode keeps every tenant's rows in one host
-        // table with a row-level filter — the behavioural default. Migrations for the
-        // table are owned by NotificationServiceDbContext via ConfigureNotificationsModule.
+        // default in-memory stores). Tenant rows carry a TenantId filtered by a
+        // row-level query filter. Migrations owned by NotificationServiceDbContext via
+        // ConfigureNotificationsModule.
         context.Builder.AddGranitNotificationsEntityFrameworkCore(opts =>
-        {
-            opts.StorageMode = DualScopeStorageMode.Shared;
-            opts.Configure = db => db.UseNpgsql(
-                context.Builder.Configuration.GetConnectionString("notification-db"));
-
-            // Pour activer l'isolation physique par tenant (RGPD Art. 17, ISO 27001 A.8.12):
-            // opts.StorageMode = DualScopeStorageMode.Segregated;
-            // opts.ConfigureHost = db => db.UseNpgsql(hostConnString);
-            // opts.ConfigureSchemaPerTenant = db => db.UseNpgsql(baseConnString);
-        });
+            opts.UseNpgsql(context.Builder.Configuration.GetConnectionString("notification-db")));
 
         // AddGranitNotificationsEntityFrameworkCore unconditionally registers
         // EfCoreMobilePushTokenStore, which depends on IMobilePushTokenHasher — provided


### PR DESCRIPTION
## Context

granit-dotnet reverted Epic #2382 (DualScopeStorageMode V1+V2+V3) across 6 modules
(PRs #2474–#2480 + #2480 Persistence). This PR aligns the template with the new
simplified API.

## Changes

**3 files changed:**

- `src/GranitMicroservice.IdentityService/Program.cs` — removed `DualScopeStorageMode.Shared`
  defaults, commented `Segregated` alternatives, `ConfigureHost`/`ConfigureSchemaPerTenant`
  options and `using Granit.Persistence.MultiTenancy`. Updated 3 registrations to the
  post-revert signatures:
  - `AddGranitIdentityFederatedEntityFrameworkCore(opts => opts.UseNpgsql(...))`
  - `builder.Services.AddGranitIdentityEntityFrameworkCore(opts => opts.UseNpgsql(...))`
    _(receiver moved from `IHostApplicationBuilder` to `IServiceCollection`)_
  - `AddGranitAuditingEntityFrameworkCore(opts => opts.UseNpgsql(...))`

- `src/GranitMicroservice.NotificationService/NotificationServiceModule.cs` — same
  cleanup; `AddGranitNotificationsEntityFrameworkCore(opts => opts.UseNpgsql(...))`.
  Removed `using Granit.Persistence.MultiTenancy`; kept `using Granit.Persistence.EntityFrameworkCore.Hosting` (required for `IMigratableModule<>`).

- `src/GranitMicroservice.IdentityService/Persistence/IdentityServiceDbContext.cs` —
  updated comment to remove references to the removed `IdentityFederatedHostDbContext` /
  `AuditingHostDbContext` internal types.

## Build status

**Currently broken on 4 API-mismatch errors.** The latest published package
(`0.1.0-dev.3236`) still ships the DualScope API. The errors will resolve
automatically once the granit-dotnet CI publishes post-revert packages (first build
after #2474–#2480 merged to develop).

```
IdentityFederatedEntityFrameworkCoreOptions has no UseNpgsql
IServiceCollection has no AddGranitIdentityEntityFrameworkCore  
AuditingEntityFrameworkCoreOptions has no UseNpgsql
NotificationsEntityFrameworkCoreOptions has no UseNpgsql
```

**Do not merge until CI is green.** No scaffold test was run (blocked by the same
package gap).

## NuGet versions

`Directory.Packages.props` already uses `0.1.0-dev.*` floating versions — no manual
bump needed; the first restore after packages land will pick them up.