### PR TITLE
build(deps): align with granit-dotnet — Wolverine 6, Aspire 13, coverlet 10, Roslyn pins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@
 
 ## Stack and versions
 
-.NET 10 (LTS) | C# 14 | .NET Aspire 9 | EF Core 10 | Wolverine 5.20+ | YARP
+.NET 10 (LTS) | C# 14 | .NET Aspire 13 | EF Core 10 | Wolverine 6 | YARP
 
 ## Architecture
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,25 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageFloatingVersionsEnabled>true</CentralPackageFloatingVersionsEnabled>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
+
+  <!-- Align the transitively-pulled Microsoft.CodeAnalysis.* family (EF Core Design's
+       Workspaces + Wolverine 6 runtime codegen) to 5.3.0 so it matches the SDK 10.0.x
+       compiler (Common/CSharp 5.3.0). The 5.0.0 Workspaces lacks ReduceExtensionMember,
+       which breaks `dotnet ef migrations add` C# scaffolding with a TypeLoadException.
+       Requires CentralPackageTransitivePinningEnabled (these are transitive-only). -->
+  <ItemGroup Label="Roslyn version alignment (transitive pins)">
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Scripting" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Scripting.Common" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.3.0" />
+  </ItemGroup>
 
   <!-- Granit framework -->
   <ItemGroup Label="Granit">
@@ -71,8 +89,8 @@
 
   <!-- Wolverine -->
   <ItemGroup Label="Wolverine">
-    <PackageVersion Include="WolverineFx" Version="5.20.*" />
-    <PackageVersion Include="WolverineFx.Postgresql" Version="5.20.*" />
+    <PackageVersion Include="WolverineFx" Version="6.*" />
+    <PackageVersion Include="WolverineFx.Postgresql" Version="6.*" />
   </ItemGroup>
 
   <!-- YARP -->
@@ -116,7 +134,7 @@
     <PackageVersion Include="NSubstitute" Version="5.*" />
     <PackageVersion Include="Shouldly" Version="4.*" />
     <PackageVersion Include="Bogus" Version="35.*" />
-    <PackageVersion Include="coverlet.collector" Version="8.*" />
+    <PackageVersion Include="coverlet.collector" Version="10.*" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.*" />
     <PackageVersion Include="Aspire.Hosting.Testing" Version="13.*" />
   </ItemGroup>

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -4,7 +4,7 @@ This file lists the third-party libraries used by
 **granit-microservice-template** and their respective licenses. It is updated
 whenever an external dependency is added or changed.
 
-Last updated: 2026-03-25
+Last updated: 2026-06-03
 
 ---
 
@@ -12,7 +12,7 @@ Last updated: 2026-03-25
 
 | License      | Package count |
 | ------------ | ------------- |
-| MIT          | 19            |
+| MIT          | 28            |
 | Apache-2.0   | 35            |
 | BSD-3-Clause | 2             |
 | PostgreSQL   | 1             |
@@ -33,6 +33,15 @@ Last updated: 2026-03-25
 | Aspire.Hosting.Redis | 13.x | (c) Microsoft Corporation |
 | Microsoft.AspNetCore.Authentication.JwtBearer | 10.x | (c) Microsoft Corporation |
 | Microsoft.AspNetCore.OpenApi | 10.x | (c) Microsoft Corporation |
+| Microsoft.CodeAnalysis | 5.3.0 | (c) Microsoft Corporation |
+| Microsoft.CodeAnalysis.CSharp.Scripting | 5.3.0 | (c) Microsoft Corporation |
+| Microsoft.CodeAnalysis.CSharp.Workspaces | 5.3.0 | (c) Microsoft Corporation |
+| Microsoft.CodeAnalysis.Scripting | 5.3.0 | (c) Microsoft Corporation |
+| Microsoft.CodeAnalysis.Scripting.Common | 5.3.0 | (c) Microsoft Corporation |
+| Microsoft.CodeAnalysis.VisualBasic | 5.3.0 | (c) Microsoft Corporation |
+| Microsoft.CodeAnalysis.VisualBasic.Workspaces | 5.3.0 | (c) Microsoft Corporation |
+| Microsoft.CodeAnalysis.Workspaces.Common | 5.3.0 | (c) Microsoft Corporation |
+| Microsoft.CodeAnalysis.Workspaces.MSBuild | 5.3.0 | (c) Microsoft Corporation |
 | Microsoft.EntityFrameworkCore | 10.x | (c) Microsoft Corporation |
 | Microsoft.EntityFrameworkCore.Design | 10.x | (c) Microsoft Corporation |
 | Microsoft.EntityFrameworkCore.Relational | 10.x | (c) Microsoft Corporation |
@@ -41,8 +50,8 @@ Last updated: 2026-03-25
 | Microsoft.Extensions.Http.Resilience | 10.x | (c) Microsoft Corporation |
 | Microsoft.Extensions.ServiceDiscovery | 10.x | (c) Microsoft Corporation |
 | Scalar.AspNetCore | 2.x | Scalar Contributors |
-| WolverineFx | 5.20.x | JasperFx Contributors |
-| WolverineFx.Postgresql | 5.20.x | JasperFx Contributors |
+| WolverineFx | 6.x | JasperFx Contributors |
+| WolverineFx.Postgresql | 6.x | JasperFx Contributors |
 | Yarp.ReverseProxy | 2.x | (c) Microsoft Corporation |
 
 ### Apache-2.0
@@ -102,7 +111,7 @@ Last updated: 2026-03-25
 | ------- | ------- | --------- |
 | Aspire.Hosting.Testing | 13.x | (c) Microsoft Corporation |
 | Bogus | 35.x | Copyright (c) 2015 Brian Chavez |
-| coverlet.collector | 8.x | (c) 2018 Toni Solarin-Sodara |
+| coverlet.collector | 10.x | (c) 2018 Toni Solarin-Sodara |
 | Microsoft.NET.Test.Sdk | 18.x | (c) Microsoft Corporation |
 | Testcontainers.PostgreSql | 4.x | Copyright (c) 2019-2025 Andre Hofmeister |
 


### PR DESCRIPTION
## Summary

Align the template's dependency versions with `granit-dotnet` and fix the EF Core migrations scaffolding break.

- `WolverineFx` + `WolverineFx.Postgresql` `5.20.*` → `6.*`
- `coverlet.collector` `8.*` → `10.*`
- Pin the `Microsoft.CodeAnalysis.*` family to `5.3.0` via **transitive pinning** (`CentralPackageTransitivePinningEnabled`) so EF Core Design's Workspaces matches the SDK 10.0.x compiler
- Sync `CLAUDE.md` stack line (Aspire 9 → 13, Wolverine 5.20+ → 6) and `THIRD-PARTY-NOTICES.md` to match

## Why the Roslyn pins

EF Core Design pulled `Microsoft.CodeAnalysis.Workspaces` `5.0.0` transitively, which lacks `ReduceExtensionMember`. Combined with the SDK 10.0.x compiler (`Common`/`CSharp` `5.3.0`), `dotnet ef migrations add` threw a `TypeLoadException` during C# scaffolding. Pinning the whole family to `5.3.0` realigns them.

## Test plan / DoD

- [x] Markdown lint clean (`CLAUDE.md`, `THIRD-PARTY-NOTICES.md`)
- [x] `THIRD-PARTY-NOTICES.md` updated for all dep changes (MIT count 19 → 28)
- [x] `dotnet build GranitMicroservice.slnx` — succeeded, 0 warnings / 0 errors
- [x] `dotnet test GranitMicroservice.slnx` — 35 passed, 0 failed, 0 skipped (incl. 6 Testcontainers integration tests)
- [x] `dotnet ef migrations add` no longer throws `TypeLoadException` (verified on CatalogService, throwaway migration removed)